### PR TITLE
Partial Policies and changes to Assignment classes

### DIFF
--- a/msdm/algorithms/laostar.py
+++ b/msdm/algorithms/laostar.py
@@ -22,7 +22,7 @@ class LAOStar(Plans):
     with loops. Artificial Intelligence, 129(1-2), 35-62.
     """
     def __init__(self,
-                 heuristic, # Function over states
+                 heuristic=None, # Function over states
                  egraph=None,
                  show_warning=False,
                  show_progress=True,
@@ -31,6 +31,8 @@ class LAOStar(Plans):
                  policy_iteration_iters=100,
                  discount_rate=1.0,
                  seed=None):
+        if heuristic is None:
+            heuristic = lambda s : 0.0
         A = SimpleNamespace(**{n: a for n, a in locals().items() if n != "self"})
         self.A = A
 

--- a/msdm/algorithms/laostar.py
+++ b/msdm/algorithms/laostar.py
@@ -215,7 +215,7 @@ class LAOStar(Plans):
 
         pi = Dict()
         for n in sGraph.values():
-            pi[n['state']] = DiscreteFactorTable([n['bestaction']])
+            pi[n['state']] = Dict([[n['bestaction'], 1.0]])
         pi = PartialPolicy(pi)
             
         return Result(

--- a/msdm/algorithms/laostar.py
+++ b/msdm/algorithms/laostar.py
@@ -27,6 +27,7 @@ class LAOStar(Plans):
                  max_lao_iters=100,
                  policy_evaluation_iters=100,
                  policy_iteration_iters=100,
+                 discount_rate=1.0,
                  seed=None):
         A = SimpleNamespace(**{n: a for n, a in locals().items() if n != "self"})
         self.A = A
@@ -39,7 +40,8 @@ class LAOStar(Plans):
             seed = A.seed
         random.seed(seed)
         
-        discount_rate = 1 - mdp.termination_prob
+        # discount_rate = 1 - mdp.termination_prob
+        discount_rate = A.discount_rate
         #initialize explicit graph
         if A.egraph is None:
             egraph = {} #explicit graph

--- a/msdm/algorithms/laostar.py
+++ b/msdm/algorithms/laostar.py
@@ -7,6 +7,8 @@ import numpy as np
 from msdm.core.assignment import AssignmentMap as Dict
 from msdm.core.algorithmclasses import Plans, Result
 from msdm.core.problemclasses.mdp import MarkovDecisionProcess
+from msdm.core.problemclasses.mdp.policy.partialpolicy import PartialPolicy
+from msdm.core.distributions import DiscreteFactorTable, Distribution
 
 def _hash(x):
     if isinstance(x, dict):
@@ -210,9 +212,15 @@ class LAOStar(Plans):
             
         if A.show_progress:
             pbar.close()
+
+        pi = Dict()
+        for n in sGraph.values():
+            pi[n['state']] = DiscreteFactorTable([n['bestaction']])
+        pi = PartialPolicy(pi)
             
         return Result(
             egraph=egraph,
+            policy=pi,
             sGraph=sGraph,
             laoIter=laoIter,
             nonterminaltips=ntt,

--- a/msdm/core/assignment/assignmentmap.py
+++ b/msdm/core/assignment/assignmentmap.py
@@ -1,23 +1,10 @@
 import json
 import inspect
 
-def encode_item(i):
-    if isinstance(i, (dict, list)):
-        i = json.dumps(i, sort_keys=True)
-    return i
-
-def decode_item(i):
-    try:
-        i = json.loads(i)
-    except json.JSONDecodeError:
-        pass
-    except TypeError:
-        pass
-    return i
-
 class AssignmentMap(dict):
     """Dictionary that supports simple dictionaries as keys"""
     def __init__(self, *args, **kwargs):
+        self._encoded_keys = {}#note: this isn't doing garbage collection
         dict.update(self)
         if len(args) > 0:
             for k, v in args[0]:
@@ -26,22 +13,44 @@ class AssignmentMap(dict):
             for k, v in kwargs.items():
                 self[k] = v
 
+    def encode_item(self, i):
+        if isinstance(i, (dict, list)):
+            encoded = json.dumps(i, sort_keys=True)
+            self._encoded_keys[encoded] = i
+            i = encoded
+        return i
+
+    def decode_item(self, encoded_item):
+        try:
+            return self._encoded_keys[encoded_item]
+        except KeyError:
+            return encoded_item
+        # if i in self._encoded_keys:
+        #     return self._
+        # try:
+        #     i = json.loads(i)
+        # except json.JSONDecodeError:
+        #     pass
+        # except TypeError:
+        #     pass
+        # return i
+
     def __getitem__(self, key):
-        return dict.__getitem__(self, encode_item(key))
+        return dict.__getitem__(self, self.encode_item(key))
     
     def get(self, key, default=None):
-        return dict.get(self, encode_item(key), default)
+        return dict.get(self, self.encode_item(key), default)
     
     def __setitem__(self, key, val):
-        dict.__setitem__(self, encode_item(key), val)
+        dict.__setitem__(self, self.encode_item(key), val)
     
     def __repr__(self):
         dictrepr = dict.__repr__(self)
         return '%s(%s)' % (type(self).__name__, dictrepr)
 
     def __contains__(self, i):
-        return dict.__contains__(self, encode_item(i))
-    
+        return dict.__contains__(self, self.encode_item(i))
+
     def update(self, *E, **F):
         """Updates self in place"""
         am = AssignmentMap()
@@ -62,15 +71,15 @@ class AssignmentMap(dict):
             
     def items(self):
         for k, v in dict.items(self):
-            yield decode_item(k), v
+            yield self.decode_item(k), v
     
     def keys(self):
         for k in dict.keys(self):
-            yield decode_item(k)
+            yield self.decode_item(k)
     
     def __iter__(self):
         for k in dict.__iter__(self):
-            yield decode_item(k)
+            yield self.decode_item(k)
 
 class DefaultAssignmentMap(AssignmentMap):
     '''

--- a/msdm/core/assignment/assignmentset.py
+++ b/msdm/core/assignment/assignmentset.py
@@ -1,40 +1,67 @@
 import json
 from itertools import chain
-from .assignmentmap import encode_item, decode_item
+# from .assignmentmap import encode_item, decode_item
 
 class AssignmentSet:
     def __init__(self, items=()):
+        self._encoded_keys = {} #note: this isn't doing garbage collection
         self._items = set([])
         for i in items:
-            self._items.add(encode_item(i))
+            self._items.add(self.encode_item(i))
+
+
+    def encode_item(self, i):
+        if isinstance(i, (dict, list)):
+            encoded = json.dumps(i, sort_keys=True)
+            self._encoded_keys[encoded] = i
+            i = encoded
+        return i
+
+    def decode_item(self, encoded_item):
+        try:
+            return self._encoded_keys[encoded_item]
+        except KeyError:
+            return encoded_item
 
     def add(self, i):
-        self._items.add(encode_item(i))
+        self._items.add(self.encode_item(i))
     
     def remove(self, i):
-        self._items.remove(encode_item(i))
-    
+        self._items.remove(self.encode_item(i))
+
+    def __merge__(self, other, new_set):
+        merged = AssignmentSet()
+        for ei in new_set:
+            try:
+                i = self.decode_item(ei)
+            except KeyError:
+                i = other.decode_item(ei)
+            merged.add(i)
+        return merged
+
     def __and__(self, other: "AssignmentSet"):
-        return AssignmentSet(self._items & other._items)
+        return self.__merge__(other, self._items & other._items)
+        # return AssignmentSet(self._items & other._items)
     
     def __or__(self, other: "AssignmentSet"):
-        return AssignmentSet(self._items | other._items)
-    
+        return self.__merge__(other, self._items | other._items)
+
     def __sub__(self, other: "AssignmentSet"):
-        return AssignmentSet(self._items - other._items)
+        return self.__merge__(other, self._items - other._items)
+        # return AssignmentSet(self._items - other._items)
 
     def __contains__(self, i):
-        return self._items.__contains__(encode_item(i))
+        return self._items.__contains__(self.encode_item(i))
     
     def __iter__(self):
         for i in self._items:
-            yield decode_item(i)
+            yield self.decode_item(i)
 
     def __len__(self):
         return len(self._items)
 
     def pop(self):
-        return decode_item(self._items.pop())
+        return self.decode_item(self._items.pop())
     
     def __repr__(self):
         return self._items.__repr__()

--- a/msdm/core/problemclasses/mdp/policy/partialpolicy.py
+++ b/msdm/core/problemclasses/mdp/policy/partialpolicy.py
@@ -14,6 +14,7 @@ class PartialPolicy(Policy):
                 raise Exception("No default action distribution set")
             raise NotImplementedError
         adist = self._policydict[s]
+        assert isinstance(adist, dict)
         a, p = zip(*adist.items())
         return DiscreteFactorTable(support=a, probs=p)
 

--- a/msdm/core/problemclasses/mdp/policy/partialpolicy.py
+++ b/msdm/core/problemclasses/mdp/policy/partialpolicy.py
@@ -1,0 +1,22 @@
+from typing import Mapping
+
+from msdm.core.problemclasses.mdp.policy.policy import Policy
+from msdm.core.distributions import DiscreteFactorTable, Distribution
+
+class PartialPolicy(Policy):
+    def __init__(self, policy_dict, default_actions=None):
+        self._policydict = policy_dict
+        self._defaults = default_actions
+
+    def action_dist(self, s) -> Distribution:
+        if (s not in self._policydict):
+            if (self._defaults is None):
+                raise Exception("No default action distribution set")
+            raise NotImplementedError
+        adist = self._policydict[s]
+        a, p = zip(*adist.items())
+        return DiscreteFactorTable(support=a, probs=p)
+
+    @property
+    def policy_dict(self) -> Mapping:
+        return self._policydict

--- a/msdm/tests/domains/__init__.py
+++ b/msdm/tests/domains/__init__.py
@@ -34,8 +34,9 @@ class GNTFig6_6(TabularMarkovDecisionProcess):
         return s in (12, 15, 16)
 
     def actions(self, s) -> Iterable:
-        dests = GNTFig6_6.T[s]
-        return [a for a in range(len(dests)) if dests[a][0]]
+        return [0, 1, 2]
+        # dests = GNTFig6_6.T[s]
+        # return [a for a in range(len(dests)) if dests[a][0]]
 
     def next_state_dist(self, s, a):
         if a < len(GNTFig6_6.T[s]):

--- a/msdm/tests/test_laostar.py
+++ b/msdm/tests/test_laostar.py
@@ -37,6 +37,9 @@ class LAOStarTestCase(unittest.TestCase):
             seed=6066253173235511770
         )
         R = lao.plan_on(mdp)
+        traj = R.policy.run_on(mdp)
+        print(traj.state_traj)
+        assert traj.state_traj[-1] == goal
         
 if __name__ == '__main__':
     unittest.main()

--- a/msdm/tests/test_lrtdp.py
+++ b/msdm/tests/test_lrtdp.py
@@ -57,7 +57,7 @@ class LRTDPTestCase(unittest.TestCase):
 
     def test_GNTFig6_6(self):
         mdp = GNTFig6_6()
-        m = LRTDP()
+        m = LRTDP(seed=12388)
         self.assert_equal_value_iteration(m, mdp)
 
     def assert_equal_value_iteration(self, planner, mdp):

--- a/msdm/tests/test_lrtdp.py
+++ b/msdm/tests/test_lrtdp.py
@@ -67,8 +67,8 @@ class LRTDPTestCase(unittest.TestCase):
         vi_res = vi.plan_on(mdp)
 
         # Ensure our VI Q values are a lower bound to the LRTDP ones.
-        for s in mdp.state_list:
-            for a in mdp.action_list:
+        for s in lrtdp_res.Q.keys():
+            for a in mdp.actions(s):
                 assert vi_res.Q[s][a] <= lrtdp_res.Q[s][a]
 
         def policy(s):


### PR DESCRIPTION
I've made some changes to LRTDP and LAO* so they can return partial policies defined over subsets of the state space (previously, they returned policies over the entire state space). This required several changes:
1. Defining a PartialPolicy class 
2. Changing some of the internals of LRTDP (and LAO*)
3. Changing some of the LRTDP tests (and LAO* tests)

@cgc, could you double check the LRTDP tests?

In addition, I changed the AssignmentMap and AssignmentSet classes to handle decoding differently. Now, they store the original version of the object and return it when "decoding" needs to happen. Note that this isn't doing garbage collection right now.