### PR TITLE
Small tweaks, and performance improvement for uncached MDPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ mainly for cog sci research.
 
 ## Installation
 
+### Installing from GitHub
+```bash
+$ pip install --upgrade git+https://github.com/markkho/msdm.git
+```
+
 ### Installing the package in edit mode
 
 After downloading, go into the folder and install the package locally
 (with a symlink so its updated as source file changes are made):
 
-```
+```bash
 $ pip install -e .
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ It is recommended to use a virtual environment.
 
 Related libraries:
 - [BURLAP](https://github.com/jmacglashan/burlap)
+
+## Contributing
+
+To run all tests: `make test`
+
+To run tests for some file: `python -m py.test msdm/tests/$TEST_FILE_NAME.py`
+
+To lint the code: `make lint`

--- a/msdm/algorithms/lrtdp.py
+++ b/msdm/algorithms/lrtdp.py
@@ -51,7 +51,7 @@ class LRTDP(Plans):
         res = self.res
         res.policy = AssignmentMap()
         res.Q = AssignmentMap()
-        for s in sum(self.res.trials, []):
+        for s in sum(self.res.trials, []) + [state for state, solved in res.solved.items() if solved]:
             if s in res.policy:
                 continue
             res.policy[s] = AssignmentMap([(self.policy(mdp, s), 1)])

--- a/msdm/algorithms/vectorizedvalueiteration.py
+++ b/msdm/algorithms/vectorizedvalueiteration.py
@@ -1,7 +1,7 @@
 from scipy.special import softmax, logsumexp
 import numpy as np
 from msdm.core.problemclasses.mdp import TabularPolicy, \
-    TabularMarkovDecisionProcess
+    TabularMarkovDecisionProcess, DeterministicTabularPolicy
 from msdm.core.algorithmclasses import Plans, Result
 from msdm.core.assignment import AssignmentMap
 
@@ -50,7 +50,8 @@ class VectorizedValueIteration(Plans):
         # create result object
         res = Result()
         res.mdp = mdp
-        res.policy = res.pi = TabularPolicy(mdp.state_list, mdp.action_list, policy_matrix=pi)
+        cls = TabularPolicy if self.entreg else DeterministicTabularPolicy
+        res.policy = res.pi = cls(mdp.state_list, mdp.action_list, policy_matrix=pi)
         res._valuevec = v
         vf = AssignmentMap([(s, vi) for s, vi in zip(mdp.state_list, v)])
         res.valuefunc = res.V = vf

--- a/msdm/algorithms/vectorizedvalueiteration.py
+++ b/msdm/algorithms/vectorizedvalueiteration.py
@@ -26,6 +26,7 @@ class VectorizedValueIteration(Plans):
 
         #available actions - add -inf if it is not available
         aa = am.copy()
+        assert np.all(aa[np.nonzero(aa)] == 1) # If this is true, then the next line is unnecessary.
         aa[np.nonzero(aa)] = 1
         aa = np.log(aa)
         terminal_sidx = np.where(1 - nt)[0]
@@ -43,6 +44,8 @@ class VectorizedValueIteration(Plans):
         if self.entreg:
             pi = softmax((1 / self.temp) * q, axis=-1)
         else:
+            # This ensures we assign equal probability to actions that result
+            # in the same q-values.
             pi = np.log(np.zeros_like(q))
             pi[q == np.max(q, axis=-1, keepdims=True)] = 1
             pi = softmax(pi, axis=-1)

--- a/msdm/core/distributions/discretefactortable.py
+++ b/msdm/core/distributions/discretefactortable.py
@@ -21,6 +21,10 @@ class DiscreteFactorTable(Distribution):
     def __init__(self, support, logits=None, probs=None, scores=None):
         if scores is None:
             scores = logits
+        if isinstance(support, dict):
+            assert logits is None
+            assert probs is None
+            support, scores = zip(*support.items())
         if len(support) == 0:
             probs = []
             scores = []
@@ -284,3 +288,16 @@ class DiscreteFactorTable(Distribution):
     def __repr__(self):
         e_l = ", ".join([f"{e}: {l:.2f}" for e, l in self.items()])
         return f"{self.__class__.__name__}({{{e_l}}})"
+
+    def __eq__(self, other):
+        return self.support == other.support and self.logits == other.logits
+
+    def isclose(self, other):
+        mapped = {
+            s: p
+            for s, p in self.items(probs=True)
+        }
+        for s, p in other.items(probs=True):
+            if not np.isclose(p, mapped[s]):
+                return False
+        return True

--- a/msdm/core/distributions/discretefactortable.py
+++ b/msdm/core/distributions/discretefactortable.py
@@ -21,17 +21,20 @@ class DiscreteFactorTable(Distribution):
     def __init__(self, support, logits=None, probs=None, scores=None):
         if scores is None:
             scores = logits
-        if (probs is None) and (scores is None):
-            scores = np.zeros(len(support))
         if len(support) == 0:
             probs = []
             scores = []
+        if (probs is None) and (scores is None):
+            scores = (0,)*len(support)
+            probs = (1/len(support),)*len(support)
         if probs is None:
+            assert len(support) == len(scores)
             if np.sum(scores) == -np.inf:
                 probs = np.zeros(len(support))
             else:
                 probs = softmax(scores)
         if scores is None:
+            assert len(support) == len(probs)
             scores = np.log(probs)
 
         self._probs = tuple(probs)
@@ -76,6 +79,8 @@ class DiscreteFactorTable(Distribution):
     def sample(self):
         if len(self.support) == 0:
             return
+        if len(self.support) == 1:
+            return self.support[0]
         return self.support[np.random.choice(len(self.support), p=self._probs)]
 
     def items(self, probs=False):
@@ -276,9 +281,6 @@ class DiscreteFactorTable(Distribution):
         """
         raise NotImplementedError
 
-    def __str__(self):
-        e_l = ", ".join([f"{e}: {l:.2f}" for e, l in self.items()])
-        return f"{self.__class__.__name__}{{{e_l}}}"
-
     def __repr__(self):
-        return str(self)
+        e_l = ", ".join([f"{e}: {l:.2f}" for e, l in self.items()])
+        return f"{self.__class__.__name__}({{{e_l}}})"

--- a/msdm/core/problemclasses/mdp/policy/__init__.py
+++ b/msdm/core/problemclasses/mdp/policy/__init__.py
@@ -1,2 +1,3 @@
-from msdm.core.problemclasses.mdp.policy.tabularpolicy import TabularPolicy
+from msdm.core.problemclasses.mdp.policy.tabularpolicy import TabularPolicy, DeterministicTabularPolicy
 from msdm.core.problemclasses.mdp.policy.policy import Policy
+from msdm.core.problemclasses.mdp.policy.deterministic_policy import DeterministicPolicy

--- a/msdm/core/problemclasses/mdp/policy/deterministic_policy.py
+++ b/msdm/core/problemclasses/mdp/policy/deterministic_policy.py
@@ -1,0 +1,5 @@
+class DeterministicPolicy:
+    def action(self, s):
+        ad = self.action_dist(s)
+        assert len(ad.support) == 1
+        return ad.support[0]

--- a/msdm/core/problemclasses/mdp/policy/tabularpolicy.py
+++ b/msdm/core/problemclasses/mdp/policy/tabularpolicy.py
@@ -2,6 +2,7 @@ from typing import Mapping
 import numpy as np
 
 from msdm.core.problemclasses.mdp.policy.policy import Policy
+from msdm.core.problemclasses.mdp.policy.deterministic_policy import DeterministicPolicy
 from msdm.core.problemclasses.mdp.mdp import MarkovDecisionProcess
 
 from msdm.core.assignment.assignmentmap import AssignmentMap
@@ -54,3 +55,5 @@ class TabularPolicy(Policy):
         self._policymat = pi
         return self._policymat
 
+class DeterministicTabularPolicy(TabularPolicy, DeterministicPolicy):
+    pass

--- a/msdm/core/problemclasses/mdp/tabularmdp.py
+++ b/msdm/core/problemclasses/mdp/tabularmdp.py
@@ -62,8 +62,8 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
         for si, s in enumerate(ss):
             for ai, a in enumerate(aa):
                 nsdist = self.next_state_dist(s, a)
-                for nsi, ns in enumerate(ss):
-                    tf[si, ai, nsi] = nsdist.prob(ns)
+                for ns, nsp in nsdist.items(probs=True):
+                    tf[si, ai, ss.index(ns)] = nsp
         self._tfmatrix = tf
         return self._tfmatrix
 
@@ -99,11 +99,9 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
         for si, s in enumerate(ss):
             for ai, a in enumerate(aa):
                 nsdist = self.next_state_dist(s, a)
-                for nsi, ns in enumerate(ss):
-                    if ns not in nsdist.support:
-                        continue
-                    r = self.reward(s, a, ns)
-                    rf[si, ai, nsi] = r
+                for ns in nsdist.support:
+                    nsi = ss.index(ns)
+                    rf[si, ai, nsi] = self.reward(s, a, ns)
         self._rfmatrix = rf
         return self._rfmatrix
 
@@ -190,4 +188,3 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
 class ANDTabularMarkovDecisionProcess(ANDMarkovDecisionProcess,
                                       TabularMarkovDecisionProcess):
     pass
-

--- a/msdm/tests/domains/__init__.py
+++ b/msdm/tests/domains/__init__.py
@@ -1,7 +1,7 @@
 from typing import Iterable
 
-from msdm.core.problemclasses.mdp import TabularMarkovDecisionProcess
-from msdm.core.distributions import DiscreteFactorTable, Distribution
+from msdm.core.problemclasses.mdp import TabularMarkovDecisionProcess, DeterministicShortestPathProblem
+from msdm.core.distributions import DiscreteFactorTable, Distribution, Multinomial
 
 class GNTFig6_6(TabularMarkovDecisionProcess):
     T = [
@@ -50,25 +50,53 @@ class GNTFig6_6(TabularMarkovDecisionProcess):
             return -GNTFig6_6.T[s][a][1]
         return -100 # HACK
 
-class CountToTen(TabularMarkovDecisionProcess):
-    def is_terminal(self, s):
-        return s == 10
+class Counter(TabularMarkovDecisionProcess, DeterministicShortestPathProblem):
+    '''
+    MDP where actions are increment/decrement and goal is to reach some count.
+    '''
+    def __init__(self, goal):
+        self.goal = goal
 
-    def next_state_dist(self, s, a):
-        if s == 10:
-            return DiscreteFactorTable([])
-        return DiscreteFactorTable([s+a])
+    def initial_state(self):
+        return 0
 
     def actions(self, s):
-        if s < 0:
-            return DiscreteFactorTable([1])
-        if s < 5:
-            return DiscreteFactorTable([1, -1])
-        return DiscreteFactorTable([1])
+        return [1, -1]
 
-    def initial_state_dist(self):
-        return DiscreteFactorTable([0,])
+    def next_state(self, s, a):
+        ns = s + a
+        if ns < 0 or self.goal < ns:
+            return s
+        return ns
 
     def reward(self, s, a, ns):
         return -1
 
+    def is_terminal(self, s):
+        return s == self.goal
+
+class Geometric(TabularMarkovDecisionProcess):
+    '''
+    MDP where actions are to draw from a Bernoulli or wait.
+    Goal is to get a 1 from the Bernoulli, which has probability `p`.
+    '''
+    def __init__(self, *, p=1/2):
+        self.p = p
+
+    def initial_state_dist(self):
+        return Multinomial([0])
+
+    def actions(self, s):
+        return ['flip', 'wait']
+
+    def next_state_dist(self, s, a):
+        if a == 'wait':
+            return Multinomial([s])
+        elif a == 'flip':
+            return Multinomial([0, 1], probs=[1-self.p, self.p])
+
+    def reward(self, s, a, ns):
+        return -1
+
+    def is_terminal(self, s):
+        return s == 1

--- a/msdm/tests/test_core_distributions.py
+++ b/msdm/tests/test_core_distributions.py
@@ -14,34 +14,36 @@ np.seterr(divide='ignore')
 
 class DistributionTestCase(unittest.TestCase):
     def test_basics(self):
-        cls = Multinomial
+        DiscreteFactorTable = Pr
+        for cls in [Multinomial, DiscreteFactorTable]:
+            print(cls)
+            dist = cls({0: 0, 1: 1}) # Can construct with a logit dict
+            assert dist == cls([0, 1], logits=[0, 1]) # or explicitly
+            assert dist == cls([0, 1], scores=[0, 1]) # or explicitly
 
-        dist = cls({0: 0, 1: 1}) # Can construct with a logit dict
-        assert dist == cls([0, 1], logits=[0, 1]) # or explicitly
+            # Per Python convention for repr, we ensure we can evaluate to the same.
+            assert eval(repr(dist)) == dist
 
-        # Per Python convention for repr, we ensure we can evaluate to the same.
-        assert eval(repr(dist)) == dist
+            # Testing close but not identical ones.
+            dist_close = cls([0, 1], logits=[0, 1.000001])
+            assert dist != dist_close
+            assert dist.isclose(dist_close)
 
-        # Testing close but not identical ones.
-        dist_close = cls([0, 1], logits=[0, 1.000001])
-        assert dist != dist_close
-        assert dist.isclose(dist_close)
+            # Testing case where logits differ but describe same probability dist
+            dist_logit_fixed_dist = cls([0, 1], logits=[100, 101])
+            assert dist != dist_close
+            assert dist.isclose(dist_close)
 
-        # Testing case where logits differ but describe same probability dist
-        dist_logit_fixed_dist = cls([0, 1], logits=[100, 101])
-        assert dist != dist_close
-        assert dist.isclose(dist_close)
+            # Testing case where keys are out of order
+            dist_logit_fixed_dist = cls([1, 0], logits=[1, 0])
+            assert dist != dist_close
+            assert dist.isclose(dist_close)
 
-        # Testing case where keys are out of order
-        dist_logit_fixed_dist = cls([1, 0], logits=[1, 0])
-        assert dist != dist_close
-        assert dist.isclose(dist_close)
+            # Can do isclose to probabilities
+            assert dist.isclose(cls([0, 1], probs=softmax([1, 2])))
 
-        # Can do isclose to probabilities
-        assert dist.isclose(cls([0, 1], probs=softmax([1, 2])))
-
-        # Testing uniform distribution
-        assert cls([0, 1, 2]).isclose(cls([0, 1, 2], logits=[1, 1, 1]))
+            # Testing uniform distribution
+            assert cls([0, 1, 2]).isclose(cls([0, 1, 2], logits=[1, 1, 1]))
 
     def test_sample(self):
         for cls in [Multinomial, Pr]:

--- a/msdm/tests/test_search.py
+++ b/msdm/tests/test_search.py
@@ -2,7 +2,7 @@ import unittest
 
 from msdm.algorithms import BreadthFirstSearch, AStarSearch
 from msdm.domains import GridWorld
-from msdm.core.problemclasses.mdp import DeterministicShortestPathProblem
+from msdm.tests.domains import Counter
 
 def deterministic(dist):
     '''
@@ -35,6 +35,10 @@ class SearchTestCase(unittest.TestCase):
     def test_bfs(self):
         res = BreadthFirstSearch().plan_on(gw)
         assert [(s['x'], s['y']) for s in res.path] == [(0, 2), (1, 2), (2, 2), (-1, -1)]
+
+    def test_deterministic_shortest_path(self):
+        res = BreadthFirstSearch().plan_on(Counter(3))
+        assert res.path == [0, 1, 2, 3]
 
     def test_astarsearch(self):
         soln1 = [(0, 2), (0, 3), (0, 4), (1, 4), (2, 4), (2, 3), (2, 2), (-1, -1)]

--- a/msdm/tests/test_value_iteration.py
+++ b/msdm/tests/test_value_iteration.py
@@ -1,0 +1,22 @@
+import unittest
+
+import numpy as np
+from msdm.algorithms import VectorizedValueIteration
+from msdm.tests.domains import Counter, GNTFig6_6, Geometric
+
+class VITestCase(unittest.TestCase):
+    def test_value_iteration(self):
+        mdp = Counter(3)
+        res = VectorizedValueIteration().plan_on(mdp)
+        out = res.policy.run_on(mdp)
+        assert out.state_traj == (0, 1, 2)
+        assert out.action_traj == (1, 1, 1)
+        assert res.policy.action(0) == 1
+        assert res.policy.action(1) == 1
+        assert res.policy.action(2) == 1
+
+    def test_value_iteration_geometric(self):
+        mdp = Geometric(p=1/13)
+        res = VectorizedValueIteration(iterations=500).plan_on(mdp)
+        print(res.policy.action_dist(0))
+        assert np.isclose(res.V[0], -13), res.V


### PR DESCRIPTION
This PR brings together various changes I've been thinking about. The two largest pieces of work are:
- [x] Performance improvements to repeated VI on new MDPs https://github.com/markkho/msdm/commit/1eee724cc0ef18c5f74ba94f436b3365a1c2c32a
- [x] ~~Unit tests for Entropy Regularized VI https://github.com/markkho/msdm/commit/1be30ad7019435ffc9ca2feeb243ca453d6012cb~~ moved this over to a new branch.

for future consideration:
- Mirror functionality between Multinomial and DiscreteFactorTable (or merge them?)