### PR TITLE
Performance tweaks

### DIFF
--- a/msdm/core/problemclasses/mdp/mdp.py
+++ b/msdm/core/problemclasses/mdp/mdp.py
@@ -3,7 +3,7 @@ from collections.abc import Hashable, Mapping, Iterable
 
 from msdm.core.problemclasses.problemclass import ProblemClass
 from msdm.core.distributions import Distribution
-from msdm.core.utils.hashdictionary import HashDictionary, DefaultHashDictionary
+from msdm.core.utils.hashdictionary import HashDictionary, DefaultHashDictionary, defaultdict2
 
 
 class MarkovDecisionProcess(ProblemClass):
@@ -40,11 +40,17 @@ class MarkovDecisionProcess(ProblemClass):
                       initialize_defaults=True):
         """Generic function for mapping variables"""
         if default_value is not None:
-            return DefaultHashDictionary(
-                default_value=default_value,
-                initialize_defaults=initialize_defaults,
-                hash_function=hash_function
-            )
+            if hashable:
+                return defaultdict2(
+                    default_value=default_value,
+                    initialize_defaults=initialize_defaults,
+                )
+            else:
+                return DefaultHashDictionary(
+                    default_value=default_value,
+                    initialize_defaults=initialize_defaults,
+                    hash_function=hash_function
+                )
         if hashable:
             return {}
         else:

--- a/msdm/core/problemclasses/mdp/tabularmdp.py
+++ b/msdm/core/problemclasses/mdp/tabularmdp.py
@@ -1,7 +1,7 @@
 import json, logging
 import numpy as np
 from msdm.core.problemclasses.mdp import MarkovDecisionProcess
-from msdm.core.utils.funcutils import method_cache
+from msdm.core.utils.funcutils import method_cache, cached_property
 
 from msdm.core.assignment.assignmentset import AssignmentSet as Set
 logger = logging.getLogger(__name__)
@@ -28,41 +28,22 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
             'ast': self.absorbing_state_vec
         }
 
-    @property
+    @cached_property
     def state_list(self):
-        try:
-            return self._states
-        except AttributeError:
-            pass
         logger.info("State space unspecified; performing reachability analysis.")
-        self._states = \
-            sorted(self.reachable_states(),
-                key=self.hash_state
-            )
-        return self._states
+        return sorted(self.reachable_states(), key=self.hash_state)
 
-    @property
+    @cached_property
     def action_list(self):
-        try:
-            return self._action_list
-        except AttributeError:
-            pass
         logger.info("Action space unspecified; performing reachability analysis.")
         actions = Set([])
         for s in self.state_list:
             for a in self.actions(s):
                 actions.add(a)
-        self._action_list = sorted(actions,
-                                   key=self.hash_action
-                                   )
-        return self._action_list
+        return sorted(actions, key=self.hash_action)
 
-    @property
+    @cached_property
     def transition_matrix(self):
-        try:
-            return self._tfmatrix
-        except AttributeError:
-            pass
         ss = self.state_list
         aa = self.action_list
         tf = np.zeros((len(ss), len(aa), len(ss)))
@@ -74,15 +55,10 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
                 nsdist = self._cached_next_state_dist(s, a)
                 for ns, nsp in zip(nsdist.support, nsdist.probs):
                     tf[si, ai, ss.index(ns)] = nsp
-        self._tfmatrix = tf
-        return self._tfmatrix
+        return tf
 
-    @property
+    @cached_property
     def action_matrix(self):
-        try:
-            return self._actmatrix
-        except AttributeError:
-            pass
         ss = self.state_list
         aa = self.action_list
         am = np.zeros((len(ss), len(aa)))
@@ -93,16 +69,11 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
             else:
                 p = 0
             am[si, ai] = p
-        self._actmatrix = am
-        return self._actmatrix
+        return am
 
 
-    @property
+    @cached_property
     def reward_matrix(self):
-        try:
-            return self._rfmatrix
-        except AttributeError:
-            pass
         ss = self.state_list
         aa = self.action_list
         rf = np.zeros((len(ss), len(aa), len(ss)))
@@ -115,57 +86,31 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
                 for ns in nsdist.support:
                     nsi = ss.index(ns)
                     rf[si, ai, nsi] = self.reward(s, a, ns)
-        self._rfmatrix = rf
-        return self._rfmatrix
+        return rf
 
-    @property
+    @cached_property
     def state_action_reward_matrix(self):
-        try:
-            return self._sarfmatrix
-        except AttributeError:
-            pass
         rf = self.reward_matrix
         tf = self.transition_matrix
-        self._sarfmatrix = np.einsum("san,san->sa", rf, tf)
-        return self._sarfmatrix
+        return np.einsum("san,san->sa", rf, tf)
 
-    @property
+    @cached_property
     def initial_state_vec(self):
-        try:
-            return self._s0vec
-        except AttributeError:
-            pass
         s0 = self.initial_state_dist()
-        self._s0vec = np.array([s0.prob(s) for s in self.state_list])
-        return self._s0vec
+        return np.array([s0.prob(s) for s in self.state_list])
 
-    @property
+    @cached_property
     def nonterminal_state_vec(self):
-        try:
-            return self._ntvec
-        except AttributeError:
-            pass
         ss = self.state_list
-        self._ntvec = np.array([0 if self.is_terminal(s) else 1 for s in ss])
-        return self._ntvec
+        return np.array([0 if self.is_terminal(s) else 1 for s in ss])
 
-    @property
+    @cached_property
     def reachable_state_vec(self):
-        try:
-            return self._reachablevec
-        except AttributeError:
-            pass
         reachable = self.reachable_states()
-        self._reachablevec = np.array \
-            ([1 if s in reachable else 0 for s in self.state_list])
-        return self._reachablevec
+        return np.array([1 if s in reachable else 0 for s in self.state_list])
 
-    @property
+    @cached_property
     def absorbing_state_vec(self):
-        try:
-            return self._absorbingstatevec
-        except AttributeError:
-            pass
         def is_absorbing(s):
             actions = self.actions(s)
             for a in actions:
@@ -174,8 +119,7 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
                     if not self.is_terminal(ns):
                         return False
             return True
-        self._absorbingstatevec = np.array([is_absorbing(s) for s in self.state_list])
-        return self._absorbingstatevec
+        return np.array([is_absorbing(s) for s in self.state_list])
 
     def reachable_states(self):
         S0 = self.initial_state_dist().support

--- a/msdm/core/utils/funcutils.py
+++ b/msdm/core/utils/funcutils.py
@@ -1,8 +1,19 @@
 import inspect
 
 def cached_property(fn):
+    '''
+    Used to decorate a function that should be a @property
+    but also be cached. Worth careful consideration about
+    whether we want to use this once we're fully on to Python 3.8.
+
+    Main reason to use in place of functools.cached_property is
+    this preserves the semantics of @property, as noted by the docs:
+    > The mechanics of cached_property() are somewhat different from property().
+    > A regular property blocks attribute writes unless a setter is defined.
+    > In contrast, a cached_property allows writes.
+    '''
     spec = inspect.getfullargspec(fn)
-    assert len(spec.args) == 1
+    assert spec.args == ['self']
     assert len(spec.kwonlyargs) == 0
     assert spec.varargs is None
     assert spec.varkw is None

--- a/msdm/core/utils/funcutils.py
+++ b/msdm/core/utils/funcutils.py
@@ -1,0 +1,43 @@
+import inspect
+
+def cached_property(fn):
+    spec = inspect.getfullargspec(fn)
+    assert len(spec.args) == 1
+    assert len(spec.kwonlyargs) == 0
+    assert spec.varargs is None
+    assert spec.varkw is None
+
+    key = '_cached_'+fn.__name__
+    @property
+    def wrapped(self):
+        if not hasattr(self, key):
+            setattr(self, key, fn(self))
+        return getattr(self, key)
+    return wrapped
+
+def method_cache(fn):
+    '''
+    Avoiding functools.lru_cache since it holds onto object references
+    when applied to methods of an object, creating a referenc cycle (not great for GC).
+    Instead, preferring a strategy where cache storage lives on the object.
+    '''
+    cache_attr = '_cache_'+fn.__name__
+    cache_info_attr = '_cache_info_'+fn.__name__
+    def wrapped(self, *args, **kwargs):
+        # Since the store is object-local, we always have to ensure
+        # objects passed in have the cache initialized.
+        if not hasattr(self, cache_attr):
+            setattr(self, cache_attr, {})
+            setattr(self, cache_info_attr, dict(hits=0, misses=0))
+        cache = getattr(self, cache_attr)
+        cache_info = getattr(self, cache_info_attr)
+
+        # Now we check for this function call, and
+        # run the function if it hasn't been called before.
+        key = (args, frozenset(kwargs.items()) if kwargs else None)
+        if key not in cache:
+            cache[key] = fn(self, *args, **kwargs)
+            cache_info['misses'] += 1
+        cache_info['hits'] += 1
+        return cache[key]
+    return wrapped

--- a/msdm/core/utils/hashdictionary.py
+++ b/msdm/core/utils/hashdictionary.py
@@ -117,3 +117,28 @@ class DefaultHashDictionary(HashDictionary):
             return self.defaultvalue(key)
         return super().__getitem__(key)
 
+class defaultdict2(dict):
+    '''
+    defaultdict2 extends dict to support a default value for unset items,
+    akin to collections.defaultdict. Notably, this implementation does not store default values
+    after access, a departure from defaultdict.
+
+    The first parameter to defaultdict2 is the function used to generate values
+    returned when the dict has no set value for a key.
+
+    The defaultvalue function can either take no arguments or one argument, which corresponds
+    to the key passed to dict.__getitem__.
+    '''
+    def __init__(self, default_value, initialize_defaults=False):
+        arity = len(inspect.getfullargspec(default_value).args)
+        assert arity in (0, 1), 'Default must take either 0 or 1 arguments.'
+        self.defaultvalue = default_value if arity == 1 else lambda _: default_value()
+        self.initialize_defaults = initialize_defaults
+
+    def __getitem__(self, key):
+        if key not in self:
+            if self.initialize_defaults:
+                self[key] = self.defaultvalue(key)
+                return self[key]
+            return self.defaultvalue(key)
+        return super().__getitem__(key)

--- a/msdm/domains/gridworld/mdp.py
+++ b/msdm/domains/gridworld/mdp.py
@@ -112,7 +112,7 @@ class GridWorld(TabularMarkovDecisionProcess):
         nx, ny = x + ax, y + ay
         ns = frozendict({'x': nx, 'y': ny})
 
-        if ns not in self.state_list:
+        if ns not in self._states:
             bdist = DictDistribution({s: 1})
         elif ns in self.walls:
             bdist = DictDistribution({s: 1})


### PR DESCRIPTION
another small bunch of performance tweaks.

Main improvement is caching `next_state_dist` in `TabularMDP`. Also write a variant of `defaultdict` that's nice for some of our use-sites, replacing `DefaultHashDictionary`; however might be worth seeing where we can simply use `defaultdict` instead. The changes together give a modest 15% speed improvement in my benchmark.

Also created a `cached_property` for use in `TabularMDP`.