### PR TITLE
Tiny performance improvements

### DIFF
--- a/msdm/core/problemclasses/mdp/tabularmdp.py
+++ b/msdm/core/problemclasses/mdp/tabularmdp.py
@@ -83,13 +83,9 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
         aai = self.action_index
         tf = np.zeros((len(ss), len(aa), len(ss)))
         for s, si in ssi.items():
-            state_actions = self._cached_actions(s)
-            for a, ai in aai.items():
-                if a not in state_actions:
-                    continue
-                nsdist = self._cached_next_state_dist(s, a)
-                for ns, nsp in nsdist.items():
-                    tf[si, ai, ssi[ns]] = nsp
+            for a in self._cached_actions(s):
+                for ns, nsp in self._cached_next_state_dist(s, a).items():
+                    tf[si, aai[a], ssi[ns]] = nsp
         return tf
 
     @cached_property
@@ -100,12 +96,8 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
         aai = self.action_index
         am = np.zeros((len(ss), len(aa)))
         for s, si in ssi.items():
-            for a, ai in aai.items():
-                if a in self._cached_actions(s):
-                    p = 1
-                else:
-                    p = 0
-                am[si, ai] = p
+            for a in self._cached_actions(s):
+                am[si, aai[a]] = 1
         return am
 
     @cached_property
@@ -116,13 +108,9 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
         aai = self.action_index
         rf = np.zeros((len(ss), len(aa), len(ss)))
         for s, si in ssi.items():
-            state_actions = self._cached_actions(s)
-            for a, ai in aai.items():
-                if a not in state_actions:
-                    continue
-                nsdist = self._cached_next_state_dist(s, a)
-                for ns in nsdist.support:
-                    rf[si, ai, ssi[ns]] = self.reward(s, a, ns)
+            for a in self._cached_actions(s):
+                for ns in self._cached_next_state_dist(s, a).support:
+                    rf[si, aai[a], ssi[ns]] = self.reward(s, a, ns)
         return rf
 
     @cached_property

--- a/msdm/core/utils/funcutils.py
+++ b/msdm/core/utils/funcutils.py
@@ -1,4 +1,4 @@
-import inspect
+import inspect, functools
 
 def cached_property(fn):
     '''
@@ -20,6 +20,7 @@ def cached_property(fn):
 
     key = '_cached_'+fn.__name__
     @property
+    @functools.wraps(fn)
     def wrapped(self):
         if not hasattr(self, key):
             setattr(self, key, fn(self))
@@ -34,6 +35,7 @@ def method_cache(fn):
     '''
     cache_attr = '_cache_'+fn.__name__
     cache_info_attr = '_cache_info_'+fn.__name__
+    @functools.wraps(fn)
     def wrapped(self, *args, **kwargs):
         # Since the store is object-local, we always have to ensure
         # objects passed in have the cache initialized.


### PR DESCRIPTION
Two changes: one adds appropriate metadata to decorated functions (thought this would make profiles easier to read but didn't...) the other streamlines some TMDP computations; in my benchmark this seems to result in a very modest 4% performance gain, since it avoids the `not in` check on `actions()` and might avoid computation for invalid actions for states (not really an issue for the MDPs we usually use). I especially like the former since it makes these computations a bit more straightforward to read & more similar across computations. In particular, it makes one proposal I've floated look a lot clearer:
```
    @cached_property
    def _compute_mats(self):
        ssi = self.state_index
        aai = self.action_index
        tf = np.zeros((len(ss), len(aa), len(ss)))
        am = np.zeros((len(ss), len(aa)))
        rf = np.zeros((len(ss), len(aa), len(ss)))
        for s, si in ssi.items():
            for a in self._cached_actions(s):
                am[si, aai[a]] = 1
                for ns, nsp in self._cached_next_state_dist(s, a).items():
                    tf[si, aai[a], ssi[ns]] = nsp
                    rf[si, aai[a], ssi[ns]] = self.reward(s, a, ns)
        return tf, rf, am
```
While I didn't include this change in the PR, it's something that would yield another 6% or so improvement; I think too modest given that it might make the code harder to follow.