### PR TITLE
Fix UniformDistribution duplicate elements, add default impl of FiniteDistribution.__len__

### DIFF
--- a/msdm/core/distributions/dictdistribution.py
+++ b/msdm/core/distributions/dictdistribution.py
@@ -15,8 +15,6 @@ class UniformDistribution(FiniteDistribution):
         return 0
     def sample(self, *, rng=random):
         return rng.choice(self._support)
-    def __len__(self):
-        return len(self._support)
 
 class DeterministicDistribution(FiniteDistribution):
     def __init__(self, value):
@@ -32,8 +30,6 @@ class DeterministicDistribution(FiniteDistribution):
         return self.value
     def items(self):
         yield self.value, 1
-    def __len__(self):
-        return 1
 
 class DictDistribution(dict,FiniteDistribution):
     @classmethod
@@ -60,7 +56,6 @@ class DictDistribution(dict,FiniteDistribution):
 
     items = dict.items
     values = dict.values
-    __len__ = dict.__len__
     __or__ = FiniteDistribution.__or__
     __and__ = FiniteDistribution.__and__
     __mul__ = FiniteDistribution.__mul__

--- a/msdm/core/distributions/dictdistribution.py
+++ b/msdm/core/distributions/dictdistribution.py
@@ -6,11 +6,15 @@ import random
 class UniformDistribution(FiniteDistribution):
     def __init__(self, support):
         self._support = support
+        self._support_set = set(support)
+        assert len(self._support) == len(self._support_set), (
+            f'Invalid support {self._support}: some event is duplicated.'
+        )
     @property
     def support(self):
         return self._support
     def prob(self, e):
-        if e in self._support:
+        if e in self._support_set:
             return 1/len(self.support)
         return 0
     def sample(self, *, rng=random):

--- a/msdm/core/distributions/dictdistribution.py
+++ b/msdm/core/distributions/dictdistribution.py
@@ -4,17 +4,17 @@ import random
 
 
 class UniformDistribution(FiniteDistribution):
-    def __init__(self, support):
+    def __init__(self, support, check_unique=True):
+        if check_unique:
+            assert len(support) == len(set(support)), (
+                f'Invalid support {support}: some event is duplicated.'
+            )
         self._support = support
-        self._support_set = set(support)
-        assert len(self._support) == len(self._support_set), (
-            f'Invalid support {self._support}: some event is duplicated.'
-        )
     @property
     def support(self):
         return self._support
     def prob(self, e):
-        if e in self._support_set:
+        if e in self._support:
             return 1/len(self.support)
         return 0
     def sample(self, *, rng=random):

--- a/msdm/core/distributions/distributions.py
+++ b/msdm/core/distributions/distributions.py
@@ -21,9 +21,8 @@ class FiniteDistribution(Distribution[Event]):
     def support(self) -> Sequence[Event]:
         pass
 
-    @abstractmethod
     def __len__(self):
-        pass
+        return len(self.support)
 
     def sample(self, *, rng=random, k=1) -> Event:
         support = self.support

--- a/msdm/tests/test_core_distributions.py
+++ b/msdm/tests/test_core_distributions.py
@@ -6,6 +6,7 @@ import pandas as pd
 from scipy.special import softmax
 from msdm.core.distributions import DiscreteFactorTable, DictDistribution,\
     UniformDistribution, DeterministicDistribution, SoftmaxDistribution
+import pytest
 
 def toDF(p):
     df = pd.DataFrame(p.support)
@@ -95,9 +96,17 @@ class DistributionTestCase(unittest.TestCase):
             res = d & DictDistribution({'a': 0.5, 'b': 0.25, 'c': 0.25})
             assert res.isclose(DictDistribution({'a': 2/3, 'b': 1/3}))
 
-    def test_uniform_and_deterministic_dist(self):
-        assert DictDistribution(a=0.5, b=0.5).isclose(DictDistribution.uniform(['a', 'b']))
-        assert len(DictDistribution.uniform(['a', 'b'])) == 2
+    def test_uniform_dist(self):
+        d = DictDistribution.uniform(['a', 'b'])
+        assert DictDistribution(a=0.5, b=0.5).isclose(d)
+        assert len(d) == 2
+
+        # Handles duplicates by raising
+        with pytest.raises(AssertionError) as e:
+            DictDistribution.uniform('abb')
+        assert 'some event is duplicated' in str(e)
+
+    def test_deterministic_dist(self):
         assert DictDistribution(a=1).isclose(DictDistribution.deterministic('a'))
         assert len(DictDistribution.deterministic('a')) == 1
 


### PR DESCRIPTION
- Fixes #59.
- Adds a default implementation of `FiniteDistribution.__len__` of `len(self.support)` -- happy to restore the distribution-specific implementations if we think they're important for performance, but would like to have a default implementation to keep the API as simple as possible.