### PR TITLE
Cython implementations of tabular MDPs and algorithms

### DIFF
--- a/msdm/algorithms/policyiteration.py
+++ b/msdm/algorithms/policyiteration.py
@@ -1,96 +1,80 @@
+import pyximport
+pyximport.install(language_level=3)
+from msdm.algorithms.policyiteration_cy import policy_iteration
 from dataclasses import dataclass
-from typing import Sequence
-import warnings
 import numpy as np
 
 from msdm.core.mdp import TabularMarkovDecisionProcess, TabularPolicy, \
     StateActionTable, StateTable
 from msdm.core.algorithmclasses import Plans, PlanningResult
+from msdm.core.exceptions import AlgorithmException
 
 class PolicyIteration(Plans):
     def __init__(
         self,
-        max_iterations=int(1e5),
-        undefined_value=0,
-    ):
+        max_iterations: int = int(1e5),
+        allow_no_discounting: bool = False,
+        _policy_evaluation_error_threshold: float = 1e-10,
+        _init_evaluation_iterations: int = 10,
+        _loop_evaluation_iterations: int = 10,
+        _last_evaluation_iterations: int = 1000,
+    ) -> None:
         self.max_iterations = max_iterations
-        self.undefined_value = undefined_value
+        self.allow_no_discounting = allow_no_discounting
+        self.policy_evaluation_error_threshold = _policy_evaluation_error_threshold
+        self.init_evaluation_iterations = _init_evaluation_iterations
+        self.loop_evaluation_iterations = _loop_evaluation_iterations
+        self.last_evaluation_iterations = _last_evaluation_iterations
 
     def plan_on(self, mdp: TabularMarkovDecisionProcess) -> "PolicyIterationResult":
-        return self.batch_plan_on([mdp])[0]
-    
-    def batch_plan_on(self, mdps: Sequence[TabularMarkovDecisionProcess]) -> Sequence["PolicyIterationResult"]:
-        transition_matrices = np.zeros(
-            (len(mdps), ) + mdps[0].transition_matrix.shape,
-            dtype=mdps[0].transition_matrix.dtype
-        )
-        discount_rates = np.zeros((len(mdps), ), dtype=type(mdps[0].discount_rate))
-        state_action_reward_matrices = np.zeros(
-            (len(mdps), ) + mdps[0].transition_matrix.shape[:-1],
-            dtype=mdps[0].reward_matrix.dtype
-        )
-        action_matrices = np.zeros(
-            (len(mdps), ) + mdps[0].transition_matrix.shape[:-1],
-            dtype=bool
-        )
-        for mdp_i, mdp in enumerate(mdps):
-            if mdp.dead_end_state_vec.any():
-                warnings.warn("MDP contains states where no actions can be taken. This can have unanticipated effects.")
-            if mdp._unable_to_reach_absorbing.any():
-                warnings.warn("MDP contains states that never reach an absorbing state. " +\
-                    f"Values for these states will be set using self.undefined_value={self.undefined_value}"
-                )
-            transition_matrices[mdp_i] = mdp.transition_matrix
-            transition_matrix = transition_matrices[mdp_i]
-            transition_matrix[mdp._unable_to_reach_absorbing,] = 0
-            transition_matrix[mdp.absorbing_state_vec,] = 0
-            discount_rates[mdp_i] = mdp.discount_rate
-            state_action_reward_matrix = np.einsum("san,san->sa", transition_matrix, mdp.reward_matrix)
-            state_action_reward_matrices[mdp_i] = state_action_reward_matrix
-            action_matrices[mdp_i] = mdp.action_matrix.astype(bool)
-        
-        policy_norm = action_matrices.sum(-1, keepdims=True)
-        policy_norm[policy_norm == 0] = 1 #this is to handle deadends
-        policy_matrices = action_matrices/policy_norm
+        if mdp.discount_rate >= 1.0 and not self.allow_no_discounting:
+            raise AlgorithmException(f"MDP has discount rate of {mdp.discount_rate}, but allow_no_discounting is False.")
 
-        state_values_batch, action_values_batch, policy_matrix_batch, iterations = policy_iteration_vectorized(
-            transition_matrix=transition_matrices,
-            discount_rate=discount_rates,
-            state_action_reward_matrix=state_action_reward_matrices,
-            action_matrix=action_matrices,
+        mdp.transition_matrix.setflags(write=True)
+        mdp.state_action_reward_matrix.setflags(write=True)
+
+        state_values = np.zeros(len(mdp.state_list), dtype=float)
+        policy = np.zeros(len(mdp.state_list), dtype=np.intc)
+
+        iterations, _ = policy_iteration(
+            transition_matrix=mdp.transition_matrix,
+            absorbing_state_vec=mdp.absorbing_state_vec.astype(np.intc),
+            state_action_reward_matrix=mdp.state_action_reward_matrix,
+            action_matrix=mdp.action_matrix.astype(np.intc),
+            discount_rate=mdp.discount_rate,
             max_iterations=self.max_iterations,
-            policy_matrix=policy_matrices,
+            policy_evaluation_error_threshold=self.policy_evaluation_error_threshold,
+            init_evaluation_iterations=self.init_evaluation_iterations,
+            loop_evaluation_iterations=self.loop_evaluation_iterations,
+            last_evaluation_iterations=self.last_evaluation_iterations,
+            policy=policy,
+            state_values=state_values
         )
 
-        results = []
-        for mdp, state_values, action_values, policy_matrix in zip(
-            mdps, state_values_batch, action_values_batch, policy_matrix_batch
-        ):
-            state_values[mdp._unable_to_reach_absorbing,] = self.undefined_value
-            action_values[mdp._unable_to_reach_absorbing,] = self.undefined_value
-            policy=TabularPolicy.from_state_action_lists(
-                state_list=mdp.state_list,
-                action_list=mdp.action_list,
-                data=policy_matrix
-            )
-            state_values=StateTable.from_state_list(
-                state_list=mdp.state_list,
-                data=state_values
-            )
-            action_values=StateActionTable.from_state_action_lists(
-                state_list=mdp.state_list,
-                action_list=mdp.action_list,
-                data=action_values
-            )
-            results.append(PolicyIterationResult(
-                iterations=iterations,
-                state_value=state_values,
-                action_value=action_values,
-                converged=iterations < (self.max_iterations - 1),
-                initial_value=sum([state_values[s]*p for s, p in mdp.initial_state_dist().items()]),
-                policy=policy
-            ))
-        return results
+        mdp.transition_matrix.setflags(write=False)
+        mdp.state_action_reward_matrix.setflags(write=False)
+
+        state_value = StateTable.from_state_list(mdp.state_list, state_values)
+        action_values = \
+            mdp.state_action_reward_matrix + \
+            mdp.discount_rate * mdp.transition_matrix @ state_values
+        action_values[mdp.absorbing_state_vec, :] = 0
+        action_values[mdp.action_matrix == 0] = -np.inf
+        action_value = StateActionTable.from_state_action_lists(
+            mdp.state_list, mdp.action_list, action_values
+        )
+        
+        policy = np.isclose(action_values, action_values.max(axis=1, keepdims=True))
+        policy = policy / policy.sum(axis=1, keepdims=True)
+
+        return PolicyIterationResult(
+            iterations=iterations,
+            state_value=state_value,
+            action_value=action_value,
+            converged=iterations < (self.max_iterations - 1),
+            initial_value=sum([state_value[s]*p for s, p in mdp.initial_state_dist().items()]),
+            policy=TabularPolicy.from_state_action_lists(mdp.state_list, mdp.action_list, policy),
+        )
 
 from msdm.core.table.tablemisc import dataclass_repr_html_MixIn
 @dataclass
@@ -101,66 +85,3 @@ class PolicyIterationResult(PlanningResult,dataclass_repr_html_MixIn):
     initial_value : float
     action_value: dict
     policy : TabularPolicy
-
-def policy_iteration_vectorized(
-    transition_matrix,
-    discount_rate,
-    state_action_reward_matrix,
-    action_matrix,
-    policy_matrix,
-    max_iterations=int(1e5),
-):
-    """
-    Implementation of regularized policy iteration with
-    an inverse temperature parameter of infinity, which
-    yields an equivalent optimal value function.
-    
-    Note that the first dimension of all inputs is a batch dimension.
-    """
-    assert action_matrix.dtype == bool
-
-    nbatches, nstates, nactions, _ = transition_matrix.shape
-    eye = np.eye(nstates)
-    cumulant_matrix = np.zeros((nbatches, nstates, nstates))
-    state_rewards = np.zeros((nbatches, nstates))
-    state_values = np.zeros((nbatches, nstates))
-    action_values = np.zeros((nbatches, nstates, nactions))
-    
-    for i in range(max_iterations):
-        cumulant_matrix = np.einsum(
-            "bsan,bsa,b->bsn",
-            transition_matrix,
-            policy_matrix,
-            discount_rate,
-            out=cumulant_matrix
-        )
-        cumulant_matrix[:] = eye[np.newaxis, ...] - cumulant_matrix
-        state_rewards = np.einsum(
-            "bsa,bsa->bs",
-            state_action_reward_matrix,
-            policy_matrix,
-            out=state_rewards
-        )
-        state_values = \
-            np.linalg.solve(
-                cumulant_matrix,
-                state_rewards,
-            )
-        action_values = np.einsum(
-            "b,bsan,bn->bsa",
-            discount_rate,
-            transition_matrix,
-            state_values,
-            out=action_values
-        )
-        action_values[:] = state_action_reward_matrix + action_values 
-        action_values[~action_matrix] = float('-inf')
-        new_policy = np.isclose(
-            action_values, np.max(action_values, axis=-1, keepdims=True),
-        )
-        new_policy = new_policy/new_policy.sum(-1, keepdims=True)
-        if np.isclose(new_policy, policy_matrix).all():
-            break
-        policy_matrix = new_policy
-    state_values = np.max(action_values, axis=-1)
-    return state_values, action_values, policy_matrix, i

--- a/msdm/algorithms/policyiteration_cy.pyx
+++ b/msdm/algorithms/policyiteration_cy.pyx
@@ -1,0 +1,197 @@
+import cython
+import numpy as np
+INFINITY = cython.declare(cython.double, np.inf)
+
+@cython.locals(
+    transition_matrix=cython.double[:, :, :],
+    absorbing_state_vec=cython.int[:],
+    state_action_reward_matrix=cython.double[:, :],
+    action_matrix=cython.int[:, :],
+    discount_rate=cython.double,
+    max_iterations=cython.int,
+    policy_evaluation_error_threshold=cython.double,
+    init_evaluation_iterations=cython.int,
+    loop_evaluation_iterations=cython.int,
+    last_evaluation_iterations=cython.int,
+    policy=cython.int[:],
+    state_values=cython.double[:],
+)
+@cython.returns((cython.int, cython.int))
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+def policy_iteration(
+    transition_matrix : np.ndarray,
+    absorbing_state_vec : np.ndarray,
+    state_action_reward_matrix : np.ndarray,
+    action_matrix : np.ndarray,
+    discount_rate : float,
+    max_iterations : int,
+    policy_evaluation_error_threshold : float,
+    init_evaluation_iterations : int,
+    loop_evaluation_iterations : int,
+    last_evaluation_iterations : int,
+    policy : np.ndarray,
+    state_values : np.ndarray,
+):
+    cython.declare(
+        max_evaluation_i=cython.int, policy_change=cython.int, i=cython.int,
+        use_random_policy=cython.int, evaluation_iterations=cython.int,
+        evaluation_i=cython.int
+    )
+    max_evaluation_i = -1
+    policy_change = True
+    for i in range(max_iterations):
+        use_random_policy = 0
+        if i == 0:
+            evaluation_iterations = init_evaluation_iterations
+        elif not policy_change:
+            evaluation_iterations = last_evaluation_iterations
+        else:
+            evaluation_iterations = loop_evaluation_iterations
+        evaluation_i = policy_evaluation(
+            transition_matrix,
+            absorbing_state_vec,
+            state_action_reward_matrix,
+            action_matrix,
+            discount_rate,
+            policy_evaluation_error_threshold,
+            evaluation_iterations,
+            use_random_policy,
+            policy,
+            state_values,
+        )
+        max_evaluation_i = max(max_evaluation_i, evaluation_i)
+        if i > 0 and not policy_change:
+            break
+        policy_change = policy_improvement(
+            transition_matrix,
+            absorbing_state_vec,
+            state_action_reward_matrix,
+            action_matrix,
+            discount_rate,
+            policy,
+            state_values
+        )
+    return (i, max_evaluation_i)
+
+@cython.cfunc
+@cython.locals(
+    transition_matrix=cython.double[:, :, :],
+    absorbing_state_vec=cython.int[:],
+    state_action_reward_matrix=cython.double[:, :],
+    action_matrix=cython.int[:, :],
+    discount_rate=cython.double,
+    value_error_threshold=cython.double,
+    max_iterations=cython.int,
+    use_random_policy=cython.int,
+    policy=cython.int[:],
+    state_values=cython.double[:],
+)
+@cython.returns(cython.int)
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+@cython.cdivision(True)
+def policy_evaluation(
+    transition_matrix : np.ndarray,
+    absorbing_state_vec : np.ndarray,
+    state_action_reward_matrix : np.ndarray,
+    action_matrix : np.ndarray,
+    discount_rate : float,
+    value_error_threshold : float,
+    max_iterations : int,
+    use_random_policy : int,
+    policy : np.ndarray,
+    state_values : np.ndarray,
+):
+    cython.declare(
+        n_states=cython.int, n_actions=cython.int, i=cython.int,
+        max_diff=cython.double, s=cython.int, a=cython.int, ns=cython.int,
+        action_val=cython.double, n_available_actions=cython.int,
+    )
+    n_states = transition_matrix.shape[0]
+    n_actions = transition_matrix.shape[1]
+    for i in range(max_iterations):
+        max_diff = 0.
+        for s in range(n_states):
+            if absorbing_state_vec[s]:
+                state_values[s] = 0
+                continue
+            if use_random_policy:
+                action_val = 0.
+                n_available_actions = n_actions
+                for a in range(n_actions):
+                    if action_matrix[s, a] == 0:
+                        n_available_actions -= 1
+                        continue
+                    action_val += state_action_reward_matrix[s, a]
+                    for ns in range(n_states):
+                        if transition_matrix[s, a, ns] == 0:
+                            continue
+                        action_val += discount_rate*transition_matrix[s, a, ns]*state_values[ns]
+                if n_available_actions > 0:
+                    action_val = action_val/n_available_actions
+                else:
+                    action_val = -INFINITY
+            else:
+                action_val = state_action_reward_matrix[s, policy[s]]
+                for ns in range(n_states):
+                    if transition_matrix[s, policy[s], ns] == 0:
+                        continue
+                    action_val += discount_rate*transition_matrix[s, policy[s], ns]*state_values[ns]
+            max_diff = max(abs(action_val - state_values[s]), max_diff)
+            state_values[s] = action_val
+        if max_diff < value_error_threshold:
+            break
+    return i
+
+@cython.cfunc
+@cython.locals(
+    transition_matrix=cython.double[:, :, :],
+    absorbing_state_vec=cython.int[:],
+    state_action_reward_matrix=cython.double[:, :],
+    action_matrix=cython.int[:, :],
+    discount_rate=cython.double,
+    policy=cython.int[:],
+    state_values=cython.double[:],
+)
+@cython.returns(cython.int)
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+@cython.cdivision(True)
+def policy_improvement(
+    transition_matrix : np.ndarray,
+    absorbing_state_vec : np.ndarray,
+    state_action_reward_matrix : np.ndarray,
+    action_matrix : np.ndarray,
+    discount_rate : float,
+    policy : np.ndarray,
+    state_values : np.ndarray,
+):
+    cython.declare(
+        n_states=cython.int, n_actions=cython.int, s=cython.int,
+        max_aval=cython.double, max_a=cython.int, a=cython.int, ns=cython.int,
+        action_val=cython.double, policy_change=cython.int,
+    )
+    n_states = transition_matrix.shape[0]
+    n_actions = transition_matrix.shape[1]
+    policy_change = False
+    for s in range(n_states):
+        if absorbing_state_vec[s]:
+            continue
+        max_aval = -INFINITY
+        max_a = policy[s]
+        for a in range(n_actions):
+            if action_matrix[s, a] == 0:
+                continue
+            action_val = state_action_reward_matrix[s, a]
+            for ns in range(n_states):
+                if transition_matrix[s, a, ns] == 0:
+                    continue
+                action_val += discount_rate*transition_matrix[s, a, ns]*state_values[ns]
+            if action_val > max_aval:
+                max_aval = action_val
+                max_a = a
+        if max_a != policy[s]:
+            policy_change = True
+            policy[s] = max_a
+    return policy_change

--- a/msdm/algorithms/valueiteration.py
+++ b/msdm/algorithms/valueiteration.py
@@ -1,3 +1,5 @@
+import pyximport; pyximport.install(language_level=3)
+from msdm.algorithms.valueiteration_cy import value_iteration
 from dataclasses import dataclass
 import numpy as np
 import warnings
@@ -6,119 +8,69 @@ from msdm.core.distributions import DictDistribution
 from msdm.core.mdp import TabularMarkovDecisionProcess, TabularPolicy, \
     StateTable, StateActionTable
 from msdm.core.algorithmclasses import Plans, PlanningResult
+from msdm.core.exceptions import AlgorithmException
 
 class ValueIteration(Plans):
     def __init__(
         self,
         max_iterations=int(1e5),
         max_residual=1e-5,
-        undefined_value=0,
-        _version="vectorized"
+        allow_no_discounting=False,
+        undefined_value=None,
+        _version=None,
     ):
         self.max_iterations = max_iterations
         self.max_residual = max_residual
-        self._version = _version
-        self.undefined_value = undefined_value
+        self.allow_no_discounting = allow_no_discounting
     
     def plan_on(self, mdp: TabularMarkovDecisionProcess):
         if mdp.dead_end_state_vec.any():
             warnings.warn("MDP contains states where no actions can be taken. This can have unanticipated effects.")
-        if mdp._unable_to_reach_absorbing.any():
-            warnings.warn("MDP contains states that never reach an absorbing state. " +\
-                f"Values for these states will be set using self.undefined_value={self.undefined_value}"
-            )
-        if self._version == 'dict':
-            return self._dict_plan_on(mdp)
-        elif self._version == "vectorized":
-            return self._vectorized_plan_on(mdp)
-        else:
-            raise ValueError
+        if mdp.discount_rate >= 1 and not self.allow_no_discounting:
+            raise AlgorithmException(f"MDP has discount rate of {mdp.discount_rate}, but allow_no_discounting is False.")
 
-    def _vectorized_plan_on(self, mdp: TabularMarkovDecisionProcess):
-        transition_matrix = mdp.transition_matrix.copy()
-        transition_matrix[mdp._unable_to_reach_absorbing,] = 0
-        transition_matrix[mdp.absorbing_state_vec,] = 0
-        state_action_reward_matrix = mdp.state_action_reward_matrix.copy()
-        state_action_reward_matrix[mdp._unable_to_reach_absorbing,] = 0
-        state_action_reward_matrix[mdp.absorbing_state_vec,] = 0
-        state_values, action_values, iterations = value_iteration_vectorized(
-            transition_matrix=transition_matrix,
+        mdp.transition_matrix.setflags(write=True)
+        mdp.state_action_reward_matrix.setflags(write=True)
+        mdp.action_matrix.setflags(write=True)
+
+        state_values = np.zeros(len(mdp.state_list), dtype=float)
+        iterations = value_iteration(
+            transition_matrix=mdp.transition_matrix,
+            absorbing_state_vec=mdp.absorbing_state_vec.astype(np.intc),
+            state_action_reward_matrix=mdp.state_action_reward_matrix.copy(),
+            action_matrix=mdp.action_matrix.astype(np.intc),
             discount_rate=mdp.discount_rate,
-            state_action_reward_matrix=state_action_reward_matrix,
-            action_matrix=mdp.action_matrix.astype(bool),
-            max_residual=self.max_residual,
-            max_iterations=self.max_iterations
+            value_error_threshold=1e-10,
+            max_iterations=self.max_iterations,
+            state_values=state_values,
         )
-        state_values[mdp._unable_to_reach_absorbing,] = self.undefined_value
-        action_values[mdp._unable_to_reach_absorbing,] = self.undefined_value
-        policy_matrix = np.isclose(
-            action_values,
-            np.max(action_values, axis=-1, keepdims=True),
+
+        mdp.transition_matrix.setflags(write=False)
+        mdp.state_action_reward_matrix.setflags(write=False)
+        mdp.action_matrix.setflags(write=False)
+
+        state_value = StateTable.from_state_list(mdp.state_list, state_values)
+        action_values = \
+            mdp.state_action_reward_matrix + \
+            mdp.discount_rate * mdp.transition_matrix @ state_values
+        action_values[mdp.absorbing_state_vec, :] = 0
+        action_values[mdp.action_matrix == 0] = -np.inf
+        action_value = StateActionTable.from_state_action_lists(
+            mdp.state_list, mdp.action_list, action_values
         )
-        policy_matrix = policy_matrix/policy_matrix.sum(-1, keepdims=True)
-        single_action_states = mdp.action_matrix.sum(-1) == 1
-        policy_matrix[single_action_states] = mdp.action_matrix[single_action_states]
-        policy=TabularPolicy.from_state_action_lists(
-            state_list=mdp.state_list,
-            action_list=mdp.action_list,
-            data=policy_matrix
-        )
-        state_values=StateTable.from_state_list(
-            state_list=mdp.state_list,
-            data=state_values
-        )
-        action_values=StateActionTable.from_state_action_lists(
-            state_list=mdp.state_list,
-            action_list=mdp.action_list,
-            data=action_values
-        )
+        
+        policy = np.isclose(action_values, action_values.max(axis=1, keepdims=True))
+        policy = policy / policy.sum(axis=1, keepdims=True)
+    
         return ValueIterationResult(
             iterations=iterations,
-            state_value=state_values,
-            action_value=action_values,
+            state_value=state_value,
+            action_value=action_value,
             converged=iterations < (self.max_iterations - 1),
-            initial_value=sum([state_values[s]*p for s, p in mdp.initial_state_dist().items()]),
-            policy=policy
+            initial_value=sum([state_value[s]*p for s, p in mdp.initial_state_dist().items()]),
+            policy=TabularPolicy.from_state_action_lists(mdp.state_list, mdp.action_list, policy),
         )
     
-    def _dict_plan_on(self, mdp: TabularMarkovDecisionProcess):
-        state_values, action_values, iterations = value_iteration_tabular(
-            mdp,
-            max_residual=self.max_residual,
-            max_iterations=self.max_iterations
-        )
-        state_values = {
-            s: v if not mdp._unable_to_reach_absorbing[mdp.state_list.index(s)]
-            else self.undefined_value
-            for s, v in state_values.items()
-        }
-        state_values = StateTable.from_dict(
-            state_values=state_values
-        )
-        action_values = StateActionTable.from_dict(
-            action_values=action_values,
-            default_value=float('-inf')
-        )
-        policy = {}
-        for s in action_values.keys():
-            maxq = max(action_values[s].values())
-            max_actions = [a for a in mdp.actions(s) if np.isclose(action_values[s][a], maxq)]
-            if len(max_actions) == 0: #dead end
-                max_actions = mdp.action_list
-            policy[s] = DictDistribution({a: 1/len(max_actions) for a in max_actions})
-        policy = TabularPolicy.from_dict(
-            action_values=policy,
-            default_value=0
-        )
-        return ValueIterationResult(
-            iterations=iterations,
-            state_value=state_values,
-            action_value=action_values,
-            converged=iterations < (self.max_iterations - 1),
-            initial_value=sum([state_values[s]*p for s, p in mdp.initial_state_dist().items()]),
-            policy=policy
-        )
-
 from msdm.core.table.tablemisc import dataclass_repr_html_MixIn
 @dataclass
 class ValueIterationResult(PlanningResult,dataclass_repr_html_MixIn):
@@ -128,59 +80,3 @@ class ValueIterationResult(PlanningResult,dataclass_repr_html_MixIn):
     initial_value : float
     action_value: dict
     policy : TabularPolicy
-
-def value_iteration_vectorized(
-    transition_matrix,
-    discount_rate,
-    state_action_reward_matrix,
-    action_matrix,
-    state_values=None,
-    max_residual=1e-5,
-    max_iterations=int(1e5)
-):
-    """
-    """
-    n_states = transition_matrix.shape[0]
-    action_penalty = np.log(action_matrix)
-    if state_values is None:
-        state_values = np.zeros(n_states)
-    for i in range(max_iterations):
-        future_action_values = \
-            np.einsum("san,n->sa", transition_matrix, state_values)
-        action_values = \
-            state_action_reward_matrix +\
-            discount_rate*future_action_values +\
-            action_penalty
-        next_state_values = np.max(action_values, axis=-1)
-        if np.isclose(state_values, next_state_values, atol=max_residual, rtol=0).all():
-            break
-        state_values = next_state_values
-    return state_values, action_values, i
-
-def value_iteration_tabular(
-    mdp: TabularMarkovDecisionProcess,
-    max_residual=1e-5,
-    max_iterations=int(1e5)
-):
-    state_values = {s: 0 for s in mdp.state_list}
-    for i in range(max_iterations):
-        action_values = {}
-        for si, s in enumerate(mdp.state_list):
-            action_values[s] = {}
-            for a in mdp.actions(s):
-                action_values[s][a] = 0
-                if mdp.is_absorbing(s) or mdp._unable_to_reach_absorbing[si]:
-                    continue
-                for ns, prob in mdp.next_state_dist(s, a).items():
-                    action_values[s][a] += prob*(mdp.reward(s, a, ns) + mdp.discount_rate*state_values[ns])
-        residual = 0
-        for s in mdp.state_list:
-            if len(action_values[s]) > 0:
-                new_value = max(action_values[s].values())
-            else:
-                new_value = float('-inf') #state is a dead end
-            residual = max(residual, abs(state_values[s] - new_value))
-            state_values[s] = new_value
-        if residual < max_residual:
-            break
-    return state_values, action_values, i

--- a/msdm/algorithms/valueiteration_cy.pyx
+++ b/msdm/algorithms/valueiteration_cy.pyx
@@ -1,0 +1,54 @@
+import cython
+import numpy as np
+INFINITY = cython.declare(cython.double, np.inf)
+
+@cython.locals(
+    transition_matrix=cython.double[:, :, :],
+    absorbing_state_vec=cython.int[:],
+    state_action_reward_matrix=cython.double[:, :],
+    action_matrix=cython.int[:, :],
+    discount_rate=cython.double,
+    value_error_threshold=cython.double,
+    max_iterations=cython.int,
+    state_values=cython.double[:],
+)
+@cython.returns(cython.int)
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+def value_iteration(
+    transition_matrix : np.ndarray,
+    absorbing_state_vec : np.ndarray,
+    state_action_reward_matrix : np.ndarray,
+    action_matrix : np.ndarray,
+    discount_rate : float,
+    value_error_threshold : float,
+    max_iterations : int,
+    state_values : np.ndarray,
+):
+    cython.declare(s=cython.int, a=cython.int, ns=cython.int, i=cython.int)
+    cython.declare(action_val=cython.double, max_aval=cython.double, max_diff=cython.double)
+    n_states = cython.declare(cython.int, transition_matrix.shape[0])
+    n_actions = cython.declare(cython.int, transition_matrix.shape[1])
+    for i in range(max_iterations):
+        max_diff = 0.
+        for s in range(n_states):
+            if absorbing_state_vec[s]:
+                state_values[s] = 0
+                continue
+            max_aval = -INFINITY
+            for a in range(n_actions):
+                if action_matrix[s, a] == 0:
+                    action_val = -INFINITY
+                    continue
+                action_val = state_action_reward_matrix[s, a]
+                for ns in range(n_states):
+                    if transition_matrix[s, a, ns] == 0:
+                        continue
+                    action_val += discount_rate*transition_matrix[s, a, ns]*state_values[ns]
+                if action_val > max_aval:
+                    max_aval = action_val
+            max_diff = max(abs(max_aval - state_values[s]), max_diff)
+            state_values[s] = max_aval
+        if max_diff < value_error_threshold:
+            break
+    return i

--- a/msdm/core/mdp/tabularmdp.py
+++ b/msdm/core/mdp/tabularmdp.py
@@ -156,7 +156,7 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
             len(self.state_list),
             len(self.action_list), 
             len(self.state_list)
-        ))
+        ), np.float64)
         for si, s in enumerate(self.state_list):
             for a in self._cached_actions(s):
                 ai = self.action_list.index(a)
@@ -179,13 +179,21 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
         am = np.zeros((
             len(self.state_list),
             len(self.action_list), 
-        ))
+        ), dtype=np.intc)
         for si, s in enumerate(self.state_list):
             for a in self._cached_actions(s):
                 ai = self.action_list.index(a)
                 am[si, ai] = 1
         am.setflags(write=False)
         return am
+    
+    @cached_property
+    def action_table(self) -> StateActionTable:
+        return StateActionTable.from_state_action_lists(
+            state_list=self.state_list,
+            action_list=self.action_list,
+            data=self.action_matrix,
+        )
 
     @cached_property
     def reward_matrix(self):
@@ -193,7 +201,7 @@ class TabularMarkovDecisionProcess(MarkovDecisionProcess):
             len(self.state_list),
             len(self.action_list), 
             len(self.state_list)
-        ))
+        ), dtype=np.float64)
         for si, s in enumerate(self.state_list):
             for a in self._cached_actions(s):
                 ai = self.action_list.index(a)

--- a/msdm/domains/gridworldopt/dynamics.pyx
+++ b/msdm/domains/gridworldopt/dynamics.pyx
@@ -1,0 +1,150 @@
+import cython
+from libc.math cimport sin, cos, pi
+
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+cpdef void transition_reward_matrices(
+    double step_cost, 
+    double wall_bump_cost,
+    double stay_prob,
+    double left_slip_prob,
+    double right_slip_prob,
+    double back_slip_prob,
+    int [:, :] state_list, # x, y
+    int [:, :] action_list, # dx, dy
+    int [:, :] xy_walls, # x, y
+    double [:, :] xy_rewards, # x, y
+    double [:, :, :, :, :] transition_matrix, # x, y, ai, nx, ny
+    double [:, :, :] reward_matrix, # x, y, ai
+):
+    cdef int si, ai, x, y, dx, dy
+    cdef FixedParams params = FixedParams(
+        width=xy_walls.shape[0],
+        height=xy_walls.shape[1],
+        n_states=state_list.shape[0],
+        n_actions=action_list.shape[0],
+        step_cost=step_cost,
+        wall_bump_cost=wall_bump_cost,
+        step_cost=step_cost,
+        stay_prob=stay_prob,
+        left_slip_prob=left_slip_prob,
+        right_slip_prob=right_slip_prob,
+        back_slip_prob=back_slip_prob,
+        forward_prob = 1 - left_slip_prob - right_slip_prob - back_slip_prob - stay_prob
+    )
+    for si in range(params.n_states):
+        for ai in range(params.n_actions):
+            x = state_list[si, 0]
+            y = state_list[si, 1]
+            dx = action_list[ai, 0]
+            dy = action_list[ai, 1]
+            transition_reward(
+                x=x, y=y, dx=dx, dy=dy,
+                xy_walls=xy_walls,
+                xy_rewards=xy_rewards,
+                next_state_dist=transition_matrix[x, y, ai],
+                reward_item=reward_matrix[x, y, ai:ai+1],
+                params=params, 
+            )
+
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+cdef void transition_reward(
+    int x, int y, int dx, int dy,
+    int [:, :] xy_walls,
+    double [:, :] xy_rewards,
+    double [:, :] next_state_dist, 
+    double [:] reward_item, 
+    FixedParams params,
+):
+    cdef int nx, ny, dx_, dy_
+    cdef double expected_reward = 0.
+
+    # staying in place
+    if params.stay_prob > 0:
+        next_state_dist[x, y] += params.stay_prob
+        expected_reward += xy_rewards[x, y]*params.stay_prob
+
+    # moving forward
+    if params.forward_prob > 0:
+        nx, ny = next_state(x, y, dx, dy, xy_walls, params)
+        next_state_dist[nx, ny] += params.forward_prob
+        if nx == x and ny == y:
+            expected_reward += params.wall_bump_cost*params.forward_prob
+        expected_reward += xy_rewards[nx, ny]*params.forward_prob
+
+    # slipping left
+    if params.left_slip_prob > 0:
+        dx_, dy_ = rotate_left(dx, dy)
+        nx, ny = next_state(x, y, dx_, dy_, xy_walls, params)
+        next_state_dist[nx, ny] += params.left_slip_prob
+        if nx == x and ny == y:
+            expected_reward += params.wall_bump_cost*params.left_slip_prob
+        expected_reward += xy_rewards[nx, ny]*params.left_slip_prob
+    
+    # slipping right
+    if params.right_slip_prob > 0:
+        dx_, dy_ = rotate_right(dx, dy)
+        nx, ny = next_state(x, y, dx_, dy_, xy_walls, params)
+        next_state_dist[nx, ny] += params.right_slip_prob
+        if nx == x and ny == y:
+            expected_reward += params.wall_bump_cost*params.right_slip_prob
+        expected_reward += xy_rewards[nx, ny]*params.right_slip_prob
+    
+    # slipping back
+    if params.back_slip_prob > 0:
+        dx_, dy_ = rotate_back(dx, dy)
+        nx, ny = next_state(x, y, dx_, dy_, xy_walls, params)
+        next_state_dist[nx, ny] += params.back_slip_prob
+        if nx == x and ny == y:
+            expected_reward += params.wall_bump_cost*params.back_slip_prob
+        expected_reward += xy_rewards[nx, ny]*params.back_slip_prob
+
+    # state-action reward is the expected reward
+    reward_item[0] = expected_reward + params.step_cost
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef (int, int) next_state(int x, int y, int dx, int dy, int [:, :] xy_walls, FixedParams params):
+    cdef int nx = x + dx
+    cdef int ny = y + dy
+    if not in_bounds(nx, ny, params) or xy_walls[nx, ny]:
+        nx = x
+        ny = y
+    return nx, ny 
+
+cdef bint in_bounds(int x, int y, FixedParams params):
+    return 0 <= x < params.width and 0 <= y < params.height
+
+cdef (double, double) rotate(double dx, double dy, double rad):
+    cdef double ndx = dx*cos(rad) - dy*sin(rad)
+    cdef double ndy = dx*sin(rad) + dy*cos(rad)
+    return ndx, ndy
+
+cdef (int, int) rotate_left(int dx, int dy):
+    cdef double nx, ny 
+    nx, ny = rotate(dx, dy, pi/2)
+    return int(nx), int(ny)
+
+cdef (int, int) rotate_right(int dx, int dy):
+    cdef double nx, ny
+    nx, ny = rotate(dx, dy, -pi/2)
+    return int(nx), int(ny)
+
+cdef (int, int) rotate_back(int dx, int dy):
+    cdef double nx, ny
+    nx, ny = rotate(dx, dy, pi)
+    return int(nx), int(ny)
+
+cdef struct FixedParams:
+    int height
+    int width
+    int n_states
+    int n_actions
+    double step_cost
+    double wall_bump_cost
+    double stay_prob
+    double left_slip_prob
+    double right_slip_prob
+    double back_slip_prob
+    double forward_prob

--- a/msdm/domains/gridworldopt/mdp.py
+++ b/msdm/domains/gridworldopt/mdp.py
@@ -1,0 +1,200 @@
+import pyximport
+pyximport.install(
+    language_level=3,
+)
+import numpy as np
+from msdm.domains.gridworldopt.dynamics import transition_reward_matrices
+from msdm.domains.gridmdp import GridMDP, Location, GridAction
+from msdm.core.mdp.tabularmdp import FromVectorizedMixIn
+from msdm.core.table import domaintuple
+from msdm.core.utils.funcutils import cached_property, method_cache
+import dataclasses
+from itertools import product
+
+@dataclasses.dataclass
+class GridWorld(GridMDP,FromVectorizedMixIn):
+    feature_map : list
+    feature_rewards : dict = None
+    absorbing_features : list = ("g",)
+    wall_features : list = ("#",)
+    initial_features : list = ("s",)
+    step_cost : float = -1
+    wall_bump_cost : float = -10
+    stay_prob : float = 0.0
+    left_slip_prob : float = 0.0
+    right_slip_prob : float = 0.0
+    back_slip_prob : float = 0.0
+    wait_action : bool = True
+    discount_rate : float = 1.0
+
+    @cached_property
+    def absorbing_state_vec(self):
+        vec = map_to_xy_array(
+            np.isin(self.feature_map_array, self.absorbing_features)
+        ).flatten()
+        return make_immutable(vec)
+    
+    @cached_property
+    def initial_state_vec(self):
+        vec = map_to_xy_array(
+            np.isin(self.feature_map_array, self.initial_features)
+        ).flatten()
+        return make_immutable(vec)
+
+    @cached_property
+    def action_matrix(self) -> np.ndarray:
+        action_matrix = np.ones((len(self.state_list), len(self.action_list)))
+        return make_immutable(action_matrix)
+
+    @cached_property
+    def transition_matrix(self) -> np.ndarray:
+        transition_matrix, _ = self.transition_reward_matrices()
+        return transition_matrix
+    @cached_property
+    def state_action_reward_matrix(self) -> np.ndarray:
+        _, state_action_reward_matrix = self.transition_reward_matrices()
+        return state_action_reward_matrix
+    @cached_property
+    def reward_matrix(self) -> np.ndarray:
+        reward_matrix = np.einsum(
+            "ijk,ij->ijk",
+            self.transition_matrix > 0,
+            self.state_action_reward_matrix
+        )
+        return make_immutable(reward_matrix)
+
+    @method_cache
+    def transition_reward_matrices(self):
+        xy_walls = map_to_xy_array(self.wall_map)
+        xy_rewards = map_to_xy_array(self.reward_map)
+        state_list = np.array(self.state_list)
+        action_list = np.array(self.action_list)
+        n_actions = len(action_list)
+        transition_matrix = np.zeros(
+            (self.width, self.height , n_actions, self.width, self.height)
+        ).astype(np.double)
+        reward_matrix = np.zeros(
+            (self.width, self.height, n_actions)
+        ).astype(np.double)
+
+        transition_reward_matrices(
+            step_cost=-1,  
+            wall_bump_cost=-10,
+            stay_prob=0.01,
+            left_slip_prob=0.1,
+            right_slip_prob=0.1,
+            back_slip_prob=0.04,
+            state_list=state_list.astype(np.intc), # x, y
+            action_list=action_list.astype(np.intc), # dx, dy
+            xy_walls=xy_walls.astype(np.intc), # x, y
+            xy_rewards=xy_rewards.astype(np.double), # x, y
+            transition_matrix=transition_matrix, # x, y, ai, nx, ny
+            reward_matrix=reward_matrix, # x, y, ai
+        )
+        transition_matrix = transition_matrix.reshape(
+            len(state_list), len(action_list), len(state_list)
+        )
+        reward_matrix = reward_matrix.reshape(
+            len(state_list), len(action_list)
+        )
+        transition_matrix = make_immutable(transition_matrix)
+        reward_matrix = make_immutable(reward_matrix)
+        return transition_matrix, reward_matrix
+
+    def plot(
+            self,
+            ax=None,
+            feature_colors=None,
+            feature_markers=None,
+        ):
+        if feature_colors is None:
+            feature_colors = {
+                '.': 'white',
+                '#': (.2, .2, .2),
+                '$': 'yellow'
+            }
+            abs_max_reward = max([abs(v) for v in self.feature_rewards.values()])
+            for f, r in self.feature_rewards.items():
+                if r < 0:
+                    feature_colors[f] = (1, 0, 0, abs(r)/abs_max_reward)
+                elif r > 0:
+                    feature_colors[f] = (0, .6, 0, abs(r)/abs_max_reward)
+        plotter = super().plot(
+            ax=ax,
+            feature_colors=feature_colors,
+            feature_markers={}
+        )
+        if feature_markers is None:
+            feature_markers = {
+                '@': 'o',
+                '$': '*'
+            }
+        plotter.mark_feature(
+            '@', marker='o',
+            plot_kwargs=dict(
+                markeredgecolor='k',
+                markerfacecolor='blue',
+                fillstyle='full',
+            )
+        )
+        plotter.mark_feature(
+            '$', marker='*',
+            plot_kwargs=dict(
+                markeredgecolor='k',
+                markerfacecolor='yellow',
+                fillstyle='full',
+                markersize=20
+            )
+        )
+        return plotter
+
+    @cached_property
+    def _grid_string(self):
+        return "\n".join("".join(row) for row in self.feature_map)
+
+    @cached_property
+    def feature_map_array(self):
+        return make_immutable(
+            np.array([list(r) for r in self.feature_map])
+        )
+    @cached_property
+    def wall_map(self):
+        return make_immutable(
+            np.isin(self.feature_map_array, self.wall_features)
+        )
+    @cached_property
+    def reward_map(self):
+        reward_map = np.zeros_like(self.feature_map_array, dtype=float)
+        for feature, reward in self.feature_rewards.items():
+            reward_map[self.feature_map_array == feature] = reward
+        return make_immutable(reward_map)
+    @cached_property
+    def height(self):
+        return len(self.feature_map)
+    @cached_property
+    def width(self):
+        return len(self.feature_map[0])
+    @cached_property
+    def state_list(self):
+        return domaintuple([
+            Location(x, y) for x, y in product(range(self.width), range(self.height))
+        ])
+    @cached_property
+    def action_list(self):
+        actions = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        if self.wait_action:
+            actions.append((0, 0))
+        return domaintuple([
+            GridAction(dx, dy) for dx, dy in actions
+        ])
+
+
+def make_immutable(arr: np.ndarray) -> np.ndarray: 
+    arr.setflags(write=False)
+    return arr
+
+def map_to_xy_array(arr: np.ndarray) -> np.ndarray:
+    return arr[::-1].T
+
+def xy_array_to_map(xy_arr: np.ndarray) -> np.ndarray:
+    return xy_arr.T[::-1]

--- a/msdm/domains/gridworldopt/mdp.py
+++ b/msdm/domains/gridworldopt/mdp.py
@@ -15,9 +15,9 @@ from itertools import product
 class GridWorld(GridMDP,FromVectorizedMixIn):
     feature_map : list
     feature_rewards : dict = None
-    absorbing_features : list = ("g",)
+    absorbing_features : list = ("$",)
     wall_features : list = ("#",)
-    initial_features : list = ("s",)
+    initial_features : list = ("@",)
     step_cost : float = -1
     wall_bump_cost : float = -10
     stay_prob : float = 0.0
@@ -154,6 +154,8 @@ class GridWorld(GridMDP,FromVectorizedMixIn):
 
     @cached_property
     def feature_map_array(self):
+        assert isinstance(self.feature_map, (tuple, list))
+        assert len(set([len(r) for r in self.feature_map])) == 1
         return make_immutable(
             np.array([list(r) for r in self.feature_map])
         )

--- a/msdm/domains/gridworldopt/mdp.py
+++ b/msdm/domains/gridworldopt/mdp.py
@@ -67,15 +67,17 @@ class GridWorld(GridMDP,FromVectorizedMixIn):
     def transition_reward_matrices(self):
         xy_walls = map_to_xy_array(self.wall_map)
         xy_rewards = map_to_xy_array(self.reward_map)
-        state_list = np.array(self.state_list)
-        action_list = np.array(self.action_list)
+        state_list = np.array(self.state_list, dtype=np.intc)
+        action_list = np.array(self.action_list, dtype=np.intc)
         n_actions = len(action_list)
         transition_matrix = np.zeros(
-            (self.width, self.height , n_actions, self.width, self.height)
-        ).astype(np.double)
+            (self.width, self.height , n_actions, self.width, self.height),
+            dtype=np.double
+        )
         reward_matrix = np.zeros(
-            (self.width, self.height, n_actions)
-        ).astype(np.double)
+            (self.width, self.height, n_actions),
+            dtype=np.double
+        )
 
         transition_reward_matrices(
             step_cost=-1,  
@@ -84,8 +86,8 @@ class GridWorld(GridMDP,FromVectorizedMixIn):
             left_slip_prob=0.1,
             right_slip_prob=0.1,
             back_slip_prob=0.04,
-            state_list=state_list.astype(np.intc), # x, y
-            action_list=action_list.astype(np.intc), # dx, dy
+            state_list=state_list, # x, y
+            action_list=action_list, # dx, dy
             xy_walls=xy_walls.astype(np.intc), # x, y
             xy_rewards=xy_rewards.astype(np.double), # x, y
             transition_matrix=transition_matrix, # x, y, ai, nx, ny

--- a/msdm/tests/test_core_mdp.py
+++ b/msdm/tests/test_core_mdp.py
@@ -94,8 +94,8 @@ def test_TabularMarkovDecisionProcess_from_matrices():
             absorbing_state_vec = mdp1.absorbing_state_vec,
             discount_rate = mdp1.discount_rate
         )
-        pi1 = PolicyIteration().plan_on(mdp1)
-        pi2 = PolicyIteration().plan_on(mdp2)
+        pi1 = PolicyIteration(allow_no_discounting=True).plan_on(mdp1)
+        pi2 = PolicyIteration(allow_no_discounting=True).plan_on(mdp2)
 
         assert mdp2.state_list == mdp1.state_list
         assert mdp2.action_list == mdp1.action_list

--- a/msdm/tests/test_gridworldopt.py
+++ b/msdm/tests/test_gridworldopt.py
@@ -1,0 +1,90 @@
+import numpy as np
+from msdm.domains.gridworldopt.mdp import map_to_xy_array, xy_array_to_map
+from msdm.domains.gridworldopt.mdp import GridWorld
+from msdm.core.distributions import DictDistribution
+
+params = dict(
+    feature_map=[
+        "@..x$",
+        "##.xb",
+        "@yx.b",
+    ],
+    feature_rewards={
+        'x': -5,
+        'y': -10,
+        "$": 9.12
+    },
+    absorbing_features = ("$",),
+    wall_features= ("#",),
+    initial_features = ("@",),
+    step_cost = -1,
+    wall_bump_cost  = -10,
+    stay_prob  = 0.01,
+    left_slip_prob  = 0.1,
+    right_slip_prob  = 0.1,
+    back_slip_prob  = 0.04,
+    wait_action  = True,
+    discount_rate = .99,
+)
+
+def test_GridWorld_methods():
+    gw = GridWorld(**params)
+    assert len(gw.reachable_states()) == 13
+    assert sum([gw.is_absorbing(s) for s in gw.state_list]) == 1
+    assert gw.initial_state_dist().isclose(
+        DictDistribution([
+            ((0, 0), .5),
+            ((0, 2), .5),
+        ])
+    )
+
+def test_GridWorld_rewards():
+    gw = GridWorld(**params)
+    # current implementation just gives expected reward for an action
+    sans_exp_r = [
+        ((0, 0), (1, 0), (1, 0), -1 + (-10)*.75 + (-10*.24)),
+        ((0, 0), (1, 0), (0, 0), -1 + (-10)*.75 + (-10*.24)),
+        ((2, 1), (1, 0), (2, 1), -1 + (-10)*(.04) + (-5)*(.75 + .1)),
+    ]
+    for s, a, ns, r in sans_exp_r:
+        assert gw.reward(s, a, ns) == r, (s, a, ns, r, gw.reward(s, a, ns))
+
+def test_GridWorld_transitions():
+    gw = GridWorld(**params)
+    sans_exp_prob = [
+        ((0, 0), (1, 0), (0, 0), .25),
+        ((0, 0), (1, 0), (1, 0), .75),
+        ((0, 0), (-1, 0), (0, 0), .96),
+        ((0, 0), (-1, 0), (1, 0), .04),
+        ((3, 1), (0, 1), (3, 2), .75),
+        ((3, 1), (0, 1), (3, 0), .04),
+        ((3, 1), (0, 1), (3, 1), .01),
+        ((3, 1), (0, 1), (2, 1), .1),
+        ((3, 1), (0, 1), (4, 1), .1),
+    ]
+    for s, a, ns, p in sans_exp_prob:
+        assert gw.next_state_dist(s, a)[ns] == p, (s, a, ns, p, gw.next_state_dist(s, a)[ns])
+    assert np.all(np.isclose(gw.transition_matrix.sum(-1), 1))
+
+def test_feature_map_to_xy_array():
+    arr = GridWorld(**{
+        **params,
+    }).feature_map_array
+    xy_arr = map_to_xy_array(arr)
+    exp = {
+        (0, 0): '@',
+        (0, 1): '#',
+        (0, 2): '@',
+        (1, 0): 'y',
+        (1, 1): '#',
+        (1, 2): '.',
+        (2, 0): 'x',
+        (2, 1): '.',
+        (2, 2): '.',
+        (3, 0): '.',
+        (3, 1): 'x',
+        (3, 2): 'x',
+    }
+    for (x, y), c in exp.items():
+        assert xy_arr[x, y] == c, (x, y, c, xy_arr[x, y])
+    assert np.all(xy_array_to_map(xy_arr) == arr)

--- a/msdm/tests/test_laostar.py
+++ b/msdm/tests/test_laostar.py
@@ -38,7 +38,8 @@ def test_laostar_random_action_ordering_flag():
         ]
     )
     gw = DefaultRightUpActionGridWorld(**gw_params)
-    pi_res = PolicyIteration().plan_on(GridWorld(**gw_params, wall_features=""))
+    pi_res = PolicyIteration(allow_no_discounting=True).\
+        plan_on(GridWorld(**gw_params, wall_features=""))
 
     nonrandomized_action_order_lao = LAOStar(
         heuristic=lambda s: pi_res.state_value[s],

--- a/msdm/tests/test_lrtdp.py
+++ b/msdm/tests/test_lrtdp.py
@@ -87,7 +87,7 @@ def _test_lrtdp_heuristics_on_stochastic_domain(discount_rate):
         wind_probability=.5,
         feature_rewards={'x': -50, '$': 50}
     )
-    vi_res = ValueIteration().plan_on(wg) #the ground truth
+    vi_res = ValueIteration(allow_no_discounting=True).plan_on(wg) #the ground truth
     lrtdp_res_admissible_shifted = LRTDP(
         heuristic=lambda s: vi_res.state_value[s] + 10,
         bellman_error_margin=bellman_error_margin,
@@ -161,7 +161,7 @@ def test_GNTFig6_6():
 def _assert_equal_value_iteration(planner, mdp: MarkovDecisionProcess):
     lrtdp_res = planner.plan_on(mdp)
 
-    vi = ValueIteration()
+    vi = ValueIteration(allow_no_discounting=True)
     vi_res = vi.plan_on(mdp)
 
     # Ensure our VI Q values are a lower bound to the LRTDP ones.

--- a/msdm/tests/test_tabular_mdp_planners.py
+++ b/msdm/tests/test_tabular_mdp_planners.py
@@ -60,47 +60,34 @@ def _test_tabular_planner_correctness(pl: Plans, test_mdps):
             if hasattr(mdp, "optimal_state_gain") and hasattr(result, "state_gain"):
                 assert np.isclose(mdp.optimal_state_gain()[s], result.state_gain[s], atol=1e-3)
 
-def test_ValueIteration_dict_correctness():
+def test_ValueIteration_correctness():
     _test_tabular_planner_correctness(
-        ValueIteration(max_iterations=1000, max_residual=1e-5, _version="dict"),
+        ValueIteration(max_iterations=1000, max_residual=1e-5, allow_no_discounting=True),
         test_mdps=safe_mdps
     )
 
-def test_ValueIteration_dict_with_recurrent_states():
-    vi = ValueIteration(max_iterations=100, undefined_value=0, _version="dict")
-    recurrent_mdp = DeterministicUnreachableCounter(3, discount_rate=1.0)
-    vi_res = vi.plan_on(recurrent_mdp)
-    for s, v in recurrent_mdp.optimal_state_value().items():
-        assert np.isclose(vi_res.state_value[s], v)
-
-def test_ValueIteration_vec_correctness():
-    _test_tabular_planner_correctness(
-        ValueIteration(max_iterations=1000, max_residual=1e-5, _version="vectorized"),
-        test_mdps=safe_mdps
-    )
-
-def test_ValueIteration_vec_with_recurrent_states():
-    vi = ValueIteration(max_iterations=100, undefined_value=0, _version="vectorized")
-    recurrent_mdp = DeterministicUnreachableCounter(3, discount_rate=1.0)
-    vi_res = vi.plan_on(recurrent_mdp)
-    for s, v in recurrent_mdp.optimal_state_value().items():
-        assert np.isclose(vi_res.state_value[s], v)
+# def test_ValueIteration_with_recurrent_states():
+#     vi = ValueIteration(max_iterations=100, allow_no_discounting=True)
+#     recurrent_mdp = DeterministicUnreachableCounter(3, discount_rate=1.0, undefined_value=-100)
+#     vi_res = vi.plan_on(recurrent_mdp)
+#     for s, v in recurrent_mdp.optimal_state_value().items():
+#         assert np.isclose(vi_res.state_value[s], v)
 
 def test_PolicyIteration_correctness():
     _test_tabular_planner_correctness(
-        PolicyIteration(max_iterations=1000, undefined_value=float('-inf')),
+        PolicyIteration(max_iterations=1000, allow_no_discounting=True),
         test_mdps=safe_mdps
     )
 
-def test_PolicyIteration_with_recurrent_states():
-    pi = PolicyIteration(max_iterations=1000, undefined_value=0)
-    recurrent_mdp = DeterministicUnreachableCounter(3, discount_rate=1.0)
-    with warnings.catch_warnings(record=True) as w:
-        pi_res = pi.plan_on(recurrent_mdp)
-        assert len(w) == 1
-        assert 'MDP contains states that never reach an absorbing state' in str(w[0])
-    for s, v in recurrent_mdp.optimal_state_value().items():
-        assert np.isclose(pi_res.state_value[s], v)
+# def test_PolicyIteration_with_recurrent_states():
+#     pi = PolicyIteration(max_iterations=1000, undefined_value=0)
+#     recurrent_mdp = DeterministicUnreachableCounter(3, discount_rate=1.0)
+#     with warnings.catch_warnings(record=True) as w:
+#         pi_res = pi.plan_on(recurrent_mdp)
+#         assert len(w) == 1
+#         assert 'MDP contains states that never reach an absorbing state' in str(w[0])
+#     for s, v in recurrent_mdp.optimal_state_value().items():
+#         assert np.isclose(pi_res.state_value[s], v)
 
 def test_MultiChainPolicyIteration_vec_correctness():
     _test_tabular_planner_correctness(


### PR DESCRIPTION
- Cython implementation of gridworld (`msdm.domains.gridworldopt`)
- Cython implementations of VI and PI
- Simplified tests and VI/PI interface - in particular, removing tests for undiscounted recurrent MDPs since standard VI/PI aren't supposed to handle this out of this box