### PR TITLE
Fix issue where A* ignored subsequent visits to states that could have improved plans.

### DIFF
--- a/msdm/tests/domains/__init__.py
+++ b/msdm/tests/domains/__init__.py
@@ -670,3 +670,42 @@ class RussellNorvigGrid_Fig17_3(RussellNorvigGrid, TestDomain):
             (3, 1): 0.,
             (3, 2): 0.,
         }
+
+class RomaniaSubsetAIMA(DeterministicShortestPathProblem, TabularMarkovDecisionProcess, TestDomain):
+    '''
+    This small weighted graph is from Figure 3.15 in Artificial Intelligence: A Modern Approach, 3rd edition.
+    It's used to illustrate an important case for Uniform Cost Search (and A* with no heuristic), where
+    a state can be subsequently encountered through a more efficient path.
+    '''
+    state_list = ('Sibiu', 'Fagaras', 'Rimnicu Vilcea', 'Pitesti', 'Bucharest')
+    costs = {
+        frozenset({'Sibiu', 'Fagaras'}): 99,
+        frozenset({'Sibiu', 'Rimnicu Vilcea'}): 80,
+        frozenset({'Rimnicu Vilcea', 'Pitesti'}): 97,
+        frozenset({'Pitesti', 'Bucharest'}): 101,
+        frozenset({'Fagaras', 'Bucharest'}): 211,
+    }
+
+    def initial_state(self):
+        return 'Sibiu'
+
+    def is_absorbing(self, s):
+        return s == 'Bucharest'
+
+    def actions(self, s):
+        return [
+            ns
+            for ns in self.state_list
+            if frozenset({s, ns}) in self.costs
+        ]
+
+    def next_state(self, s, a):
+        assert frozenset({s, a}) in self.costs
+        return a
+
+    def reward(self, s, a, ns):
+        assert a == ns, (a, ns)
+        return -self.costs[frozenset({s, ns})]
+
+    def optimal_path(self):
+        return ['Sibiu', 'Rimnicu Vilcea', 'Pitesti', 'Bucharest']

--- a/msdm/tests/test_search.py
+++ b/msdm/tests/test_search.py
@@ -253,9 +253,11 @@ def test_astarsearch_large_grid():
     )
     hv = make_manhattan_distance_heuristic(gw)
     paths = set()
+    visiteds = set()
     for seed in range(100):
         res = AStarSearch(heuristic_value=hv, randomize_action_order=True, seed=823749285 + seed).plan_on(gw)
         paths.add(tuple(res.path))
+        visiteds.add(frozenset(res.visited))
 
     assert paths == {
         _path_from_tile_array([
@@ -276,4 +278,24 @@ def test_astarsearch_large_grid():
             '.#....#m#.#.',
             '...#..#nopqr'
         ], ('a', 'r')) + (TERMINALSTATE,),
+    }
+
+    tile_array = [
+            'A#......#...',
+            'AB#########.',
+            'CAAA#.....#.',
+            '#D#AAA##..#.',
+            '.DDE#AAA#.#.',
+            '.#DEEF#A#.#.',
+            '..D#EF#AAAAA'
+    ]
+    assert visiteds == {
+        _matching_states_from_tile_array(tile_array, 'AB'),
+        _matching_states_from_tile_array(tile_array, 'AC'),
+        _matching_states_from_tile_array(tile_array, 'ABF'),
+        _matching_states_from_tile_array(tile_array, 'ACF'),
+        _matching_states_from_tile_array(tile_array, 'ABEF'),
+        _matching_states_from_tile_array(tile_array, 'ACEF'),
+        _matching_states_from_tile_array(tile_array, 'ABDEF'),
+        _matching_states_from_tile_array(tile_array, 'ACDEF'),
     }

--- a/msdm/tests/test_search.py
+++ b/msdm/tests/test_search.py
@@ -1,7 +1,41 @@
+import pytest
+
 from msdm.algorithms import BreadthFirstSearch, AStarSearch
 from msdm.core.mdp import MarkovDecisionProcess
 from msdm.domains.gridworld.mdp import GridWorld, TERMINALSTATE
-from msdm.tests.domains import DeterministicCounter
+from msdm.tests.domains import DeterministicCounter, RomaniaSubsetAIMA
+
+
+def _matching_states_from_tile_array(tile_array, matching):
+    '''
+    Returns states in `tile_array`, where the state's feature is in `matching`.
+    '''
+    return frozenset({
+        s
+        for s, feature in GridWorld(tile_array=tile_array).location_features.items()
+        if feature in matching
+    })
+
+def _path_from_tile_array(tile_array, sequence):
+    '''
+    Returns a path of states specified in `tile_array`. State features along the path
+    must start with sequence[0], proceeding until sequence[1] (inclusive).
+    '''
+    # First, index states by feature
+    by_feature = {}
+    for s, feature in GridWorld(tile_array=tile_array).location_features.items():
+        by_feature.setdefault(feature, []).append(s)
+
+    # Then, iterate over sequence to gather matches.
+    rv = []
+    sequence_start, sequence_end = sequence # end is inclusive
+    for i in range(ord(sequence_end) - ord(sequence_start) + 1):
+        curr_seq = chr(ord(sequence_start) + i)
+        ss = by_feature[curr_seq]
+        assert len(ss) == 1, f'Found {len(ss)} states matching for current sequence feature "{curr_seq}"'
+        rv.append(ss[0])
+    return tuple(rv)
+
 
 gw = GridWorld(
     tile_array=[
@@ -15,6 +49,20 @@ gw = GridWorld(
     step_cost=-1,
     discount_rate=1.0
 )
+gw.path_above = _path_from_tile_array([
+    '234',
+    '1h5',
+    '0x6',
+    '.h.',
+    '...',
+], ('0', '6')) + (TERMINALSTATE,)
+gw.path_below = _path_from_tile_array([
+    '...',
+    '.h.',
+    '0x6',
+    '1h5',
+    '234',
+], ('0', '6')) + (TERMINALSTATE,)
 
 empty_gw = GridWorld(
     tile_array=[
@@ -23,6 +71,17 @@ empty_gw = GridWorld(
         '.....',
         '.....',
         's....',
+    ],
+    feature_rewards={'g': 0},
+    step_cost=-1,
+    discount_rate=1.0
+)
+
+bottleneck_gw = GridWorld(
+    tile_array=[
+        '...#g',
+        '.#...',
+        's..#.',
     ],
     feature_rewards={'g': 0},
     step_cost=-1,
@@ -47,21 +106,17 @@ def make_manhattan_distance_heuristic(mdp : MarkovDecisionProcess):
     return manhattan_distance_heuristic
 
 def test_astarsearch():
-    path_above = ((0, 2), (0, 3), (0, 4), (1, 4), (2, 4), (2, 3), (2, 2), (-1, -1))
-    path_below = ((0, 2), (0, 1), (0, 0), (1, 0), (2, 0), (2, 1), (2, 2), (-1, -1))
-
     found = set()
-    for seed in range(10):
+    for _ in range(10):
         planner = AStarSearch(
             heuristic_value=make_manhattan_distance_heuristic(gw),
             randomize_action_order=False,
-            seed=seed + 42,
         )
         res = planner.plan_on(gw)
-        found.add(tuple([(s['x'], s['y']) for s in res.path]))
+        found.add(tuple(res.path))
     # We deterministically select one of the two paths, because we tie-break with LIFO.
     # Depends on random seed.
-    assert found == {path_below}
+    assert found == {gw.path_below}
 
     found = set()
     for seed in range(10):
@@ -71,16 +126,16 @@ def test_astarsearch():
             seed=seed + 42
         )
         res = planner.plan_on(gw)
-        found.add(tuple([(s['x'], s['y']) for s in res.path]))
+        found.add(tuple(res.path))
     # When action order is randomized, each of the optimal solutions are possible.
     # Depends on random seed, but likely.
-    assert found == {path_above, path_below}
+    assert found == {gw.path_above, gw.path_below}
 
 def test_astarsearch_tie_breaking():
     def _plan(kw):
         planner = AStarSearch(
             heuristic_value=make_manhattan_distance_heuristic(empty_gw),
-            randomize_action_order=False,
+            randomize_action_order=True,
             seed=kw.pop('seed', 42),
             **kw,
         )
@@ -111,11 +166,114 @@ def test_astarsearch_tie_breaking():
     assert res.visited == set(empty_gw.state_list) - {TERMINALSTATE}
     _check_path(res)
 
+    visited_counts = set()
     # Visits with random tie-breaking will be bounded by the above two extremes.
     for seed in range(100):
         res = _plan(dict(tie_breaking_strategy='random', seed=seed + 47283674))
-        # This is guaranteed.
         assert path_len <= len(res.visited) <= state_count
-        # This stricter bound will depend on the random seed, but is likely.
-        assert path_len < len(res.visited) < state_count
+        visited_counts.add(len(res.visited))
         _check_path(res)
+    assert visited_counts == set(range(path_len, state_count + 1))
+
+def test_astarsearch_revise_node():
+    '''
+    In this example, the heuristic might lead you to a bottleneck state via a suboptimal
+    path. This test makes sure that the optimal path through the bottleneck is still considered.
+    '''
+    path = _path_from_tile_array([
+        '...#6',
+        '.#345',
+        '012#.',
+    ], ('0', '6')) + (TERMINALSTATE,)
+
+    grid = [
+        'CCB#A',
+        'C#AAA',
+        'AAA#.',
+    ]
+
+    expected = {
+        (path, visited)
+        for visited in [
+            # This is the best case, we only consider path.
+            _matching_states_from_tile_array(grid, 'A'),
+            # In this case, we also consider one extra state, that looks good per the heuristic.
+            _matching_states_from_tile_array(grid, 'AB'),
+            # In this case, we also got derailed into considering the entire top of the problem.
+            _matching_states_from_tile_array(grid, 'ABC'),
+        ]
+    }
+
+    hv = make_manhattan_distance_heuristic(bottleneck_gw)
+    results = set()
+    for seed in range(100):
+        res = AStarSearch(
+            heuristic_value=hv,
+            randomize_action_order=True,
+            seed=seed + 58264359237,
+        ).plan_on(bottleneck_gw)
+        results.add((
+            tuple(res.path),
+            frozenset(res.visited),
+        ))
+
+    assert results == expected
+
+def test_astarsearch_no_heuristic():
+    mdp = RomaniaSubsetAIMA()
+    result = AStarSearch(heuristic_value=lambda _: 0).plan_on(mdp)
+    assert result.path == mdp.optimal_path()
+    assert result.visited == {s for s in mdp.state_list if not mdp.is_absorbing(s)}, 'All non-absorbing states should be visited.'
+
+def test_astarsearch_monotone_heuristic():
+    base_hv = make_manhattan_distance_heuristic(gw)
+    hv = lambda s: base_hv(s) * 1.1
+    with pytest.raises(AssertionError) as err:
+        res = AStarSearch(heuristic_value=hv).plan_on(gw)
+    assert 'Heuristic is non-monotonic' in str(err)
+
+    res = AStarSearch(heuristic_value=hv, assert_monotone_heuristic=False).plan_on(gw)
+    assert tuple(res.path) == gw.path_below
+
+def test_astarsearch_large_grid():
+    gw = GridWorld(
+        tile_array=[
+            's#......#...',
+            '..#########.',
+            '....#.....#.',
+            '#.#...##..#.',
+            '....#...#.#.',
+            '.#....#.#.#.',
+            '...#..#....g'
+        ],
+        feature_rewards={'g': 0},
+        absorbing_features='g',
+        step_cost=-1,
+        discount_rate=1.0,
+    )
+    hv = make_manhattan_distance_heuristic(gw)
+    paths = set()
+    for seed in range(100):
+        res = AStarSearch(heuristic_value=hv, randomize_action_order=True, seed=823749285 + seed).plan_on(gw)
+        paths.add(tuple(res.path))
+
+    assert paths == {
+        _path_from_tile_array([
+            'a#......#...',
+            'b.#########.',
+            'cdef#.....#.',
+            '#.#ghi##..#.',
+            '....#jkl#.#.',
+            '.#....#m#.#.',
+            '...#..#nopqr'
+        ], ('a', 'r')) + (TERMINALSTATE,),
+        _path_from_tile_array([
+            'a#......#...',
+            'bc#########.',
+            '.def#.....#.',
+            '#.#ghi##..#.',
+            '....#jkl#.#.',
+            '.#....#m#.#.',
+            '...#..#nopqr'
+        ], ('a', 'r')) + (TERMINALSTATE,),
+    }


### PR DESCRIPTION
@Reeche and I found a bug in the A* implementation today. Basically, the algorithm was assuming that a previously queued state could be fully skipped. However, correctly implementing the algorithm requires adding states if a more efficient path to them has been found.

I fixed the issue and made various other improvements to the A* implementation (additional assertions, comments, NamedTuple, and fix for #78), and added additional tests. Tests include a case from AIMA, example from @Reeche, and a small case where I assert on both the returned path and visited states. Restoring the previous behavior, with the diff below, now causes four tests to fail, making me confident we've caught this issue.

```diff
                 # If the state has been reached before in a lower-cost node, then we skip.
-                if ns in best_in_queue_by_state and best_in_queue_by_state[ns].cost_from_start <= next_cost_from_start:
+                if ns in best_in_queue_by_state:
                     continue
```